### PR TITLE
feat(gate): NFC tag unlock — physical-friction alternative to the slide

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,10 @@
     <!-- Lets "Go back" on the gate actually stop the watched app, not just
          send it to the background. -->
     <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
+    <!-- Optional NFC-tag unlock: scan a registered tag to open a watched app.
+         not-required so devices without NFC still install. -->
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-feature android:name="android.hardware.nfc" android:required="false" />
     <!-- Signature-level: only active if granted once via
          `adb shell pm grant <pkg> android.permission.WRITE_SECURE_SETTINGS`.
          Lets the app re-enable its own accessibility service after reinstalls. -->
@@ -57,6 +61,17 @@
             android:name=".ui.settings.SettingsActivity"
             android:exported="false"
             android:label="@string/settings_title" />
+
+        <!-- ── NFC Unlock Activity ── -->
+        <!-- Reads a tag (reader mode needs a resumed Activity, which the gate's
+             service overlay is not). noHistory + excludeFromRecents so it never
+             lingers in the back stack or task switcher. -->
+        <activity
+            android:name=".service.nfc.NfcUnlockActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:launchMode="singleTop" />
 
         <!-- ── Accessibility Service ── -->
         <!-- Detects foreground app changes; triggers intent gate and grayscale overlay -->

--- a/app/src/main/kotlin/com/defang/launcher/data/local/datastore/PreferencesDataStore.kt
+++ b/app/src/main/kotlin/com/defang/launcher/data/local/datastore/PreferencesDataStore.kt
@@ -123,6 +123,20 @@ class PreferencesDataStore @Inject constructor(
 
     suspend fun setHomeUsageEnabled(on: Boolean) = store.edit { it[KEY_HOME_USAGE] = on }
 
+    // ── NFC unlock ────────────────────────────────────────────────────────────
+    // A physical tag scan replaces the slide-to-open at the end of the gate:
+    // the tag lives somewhere inconvenient, so opening a watched app costs a
+    // walk. nfcTagUid is the hex UID of the registered tag; null = none yet.
+    private val KEY_NFC_ENABLED = booleanPreferencesKey("nfc_unlock_enabled")
+    private val KEY_NFC_TAG_UID = stringPreferencesKey("nfc_tag_uid")
+
+    val nfcUnlockEnabled: Flow<Boolean> = store.data.map { it[KEY_NFC_ENABLED] ?: false }
+    val nfcTagUid: Flow<String?> = store.data.map { it[KEY_NFC_TAG_UID] }
+
+    suspend fun setNfcUnlockEnabled(on: Boolean) = store.edit { it[KEY_NFC_ENABLED] = on }
+    suspend fun setNfcTagUid(uid: String) = store.edit { it[KEY_NFC_TAG_UID] = uid }
+    suspend fun clearNfcTagUid() = store.edit { it.remove(KEY_NFC_TAG_UID) }
+
     // ── Home screen mode ──────────────────────────────────────────────────────
     private val KEY_HOME_MODE = intPreferencesKey("home_screen_mode")
 

--- a/app/src/main/kotlin/com/defang/launcher/service/accessibility/DefangAccessibilityService.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/accessibility/DefangAccessibilityService.kt
@@ -101,6 +101,12 @@ class DefangAccessibilityService : AccessibilityService() {
     // Packages currently showing the intent gate (prevents re-trigger on internal windows)
     private val pendingGate = mutableSetOf<String>()
 
+    // The gate key whose gate is genuinely live right now — overlay up, or handed
+    // off to the NFC scan. Cleared the instant the gate resolves or is abandoned.
+    // A pendingGate entry that isn't this key is stale (a gate left unresolved,
+    // e.g. the user backgrounded the NFC scan) and must not suppress a re-gate.
+    private var activeGateKey: String? = null
+
     // Package → suppress-gate deadline set when the user taps "Go back" on the gate.
     // Needed for browsers: the adult URL is still sitting in the URL bar after
     // dismissal, so without this the very next content-changed event would
@@ -364,7 +370,13 @@ class DefangAccessibilityService : AccessibilityService() {
             if (config == null) Log.d(TAG, "no config for $pkg")
             return
         }
-        if (pkg in pendingGate) { Log.d(TAG, "gate already pending for $pkg"); return }
+        if (pkg in pendingGate) {
+            if (pkg == activeGateKey) { Log.d(TAG, "gate already pending for $pkg"); return }
+            // Stale entry: a prior gate for this app was never resolved (typically
+            // the NFC scan was backgrounded). Drop it so the gate can re-arm.
+            Log.d(TAG, "clearing stale pending gate for $pkg")
+            pendingGate.remove(pkg)
+        }
         if (pkg == currentWatchedPackage) {
             // Session active — in-app navigation or return from home screen.
             // The app is back in front, so cancel any pending debounced teardown
@@ -419,7 +431,10 @@ class DefangAccessibilityService : AccessibilityService() {
         val isAdult = match?.isAdult ?: true          // built-in fallback is always adult
         val watchKey = match?.pattern ?: "adult:$host"
 
-        if (watchKey in pendingGate) return           // gate already showing
+        if (watchKey in pendingGate) {
+            if (watchKey == activeGateKey) return      // gate genuinely still up
+            pendingGate.remove(watchKey)               // stale — let it re-arm
+        }
         if (currentWatchedPackage == pkg && currentWatchedPattern == watchKey) {
             // Same watched target still in front — keep the session and cancel any
             // debounced teardown from browser task churn.
@@ -498,11 +513,23 @@ class DefangAccessibilityService : AccessibilityService() {
                         // Hand off to the tag-scan activity: arm the result
                         // callbacks, drop the overlay, launch the reader.
                         pendingNfcUnlock = {
-                            completeGateUnlock(pkg, pattern, "nfc", config, contentTrack, gateKey)
+                            completeGateUnlock(pkg, pattern, "nfc", config, contentTrack,
+                                gateKey, relaunchApp = true)
                         }
                         pendingNfcGoBack = { completeGateGoBack(gateKey, pkg) }
                         overlayManager.dismissFullscreen()
-                        launchNfcUnlock(config.appLabel)
+                        // Send the watched app to the background first. Some apps
+                        // (Snapchat) otherwise keep "top resumed activity" status,
+                        // and the platform then refuses our NFC reader mode even
+                        // though our scan screen is on top ("Reader mode Binder was
+                        // never registered"). Home always wins; launching the
+                        // scanner from the home state gives it a clean foreground.
+                        // The unlock relaunches the app afterwards regardless.
+                        goHome()
+                        serviceScope.launch {
+                            delay(NFC_HANDOFF_HOME_SETTLE_MS)
+                            launchNfcUnlock(config.appLabel)
+                        }
                     }
                 },
                 onIntentDeclared = { intent ->
@@ -511,11 +538,22 @@ class DefangAccessibilityService : AccessibilityService() {
                 onGoBack = { completeGateGoBack(gateKey, pkg) },
             )
             overlayManager.showFullscreen(currentGateOverlay!!.view)
+            activeGateKey = gateKey
             Log.d(TAG, "gate overlay shown for $gateKey (nfc=$nfcMode)")
         }
     }
 
-    /** Shared unlock path for both the slide gate and the NFC tag scan. */
+    /**
+     * Shared unlock path for both the slide gate and the NFC tag scan.
+     *
+     * [relaunchApp] is set for the NFC path: the tag-scan activity was on top, so
+     * the watched app is no longer foreground and finishing the scan lands on the
+     * home screen (seen on Samsung). Relaunch it explicitly. The slide path leaves
+     * the app foreground under the overlay, so it must NOT relaunch (that would
+     * reset the app to its launch screen). startSession sets currentWatchedPackage
+     * first, so the relaunch's foreground event is treated as an active session,
+     * not a fresh gate.
+     */
     private fun completeGateUnlock(
         pkg: String,
         pattern: String?,
@@ -523,19 +561,28 @@ class DefangAccessibilityService : AccessibilityService() {
         config: AppConfig,
         contentTrack: ContentTrack,
         gateKey: String,
+        relaunchApp: Boolean = false,
     ) {
         pendingGate.remove(gateKey)
+        if (activeGateKey == gateKey) activeGateKey = null
         currentGateOverlay?.cancel()
         overlayManager.dismissFullscreen()
         serviceScope.launch {
             startSession(pkg, pattern, intent, config.sessionLimitMinutes,
                 config.cooldownMinutes, contentTrack)
+            if (relaunchApp) {
+                packageManager.getLaunchIntentForPackage(pkg)?.let {
+                    it.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    startActivity(it)
+                }
+            }
         }
     }
 
     /** Shared "Go back" path for both the slide gate and the NFC tag scan. */
     private fun completeGateGoBack(gateKey: String, pkg: String) {
         pendingGate.remove(gateKey)
+        if (activeGateKey == gateKey) activeGateKey = null
         gateSuppressedUntilMs[gateKey] = System.currentTimeMillis() + GO_BACK_SUPPRESS_MS
         currentGateOverlay?.cancel()
         overlayManager.dismissAll()
@@ -873,7 +920,14 @@ class DefangAccessibilityService : AccessibilityService() {
         }
     }
 
-    override fun onInterrupt() = overlayManager.dismissAll()
+    override fun onInterrupt() {
+        overlayManager.dismissAll()
+        // Overlays are gone — drop the gate bookkeeping too so a re-open re-arms.
+        pendingGate.clear()
+        activeGateKey = null
+        pendingNfcUnlock = null
+        pendingNfcGoBack = null
+    }
 
     override fun onDestroy() {
         super.onDestroy()
@@ -921,6 +975,13 @@ class DefangAccessibilityService : AccessibilityService() {
          * a still-foreground process.
          */
         const val GO_HOME_SETTLE_MS = 350L
+
+        /**
+         * Delay between backgrounding the watched app (Home) and launching the
+         * NFC scan screen, so Home settles and the scan activity comes up as the
+         * unambiguous foreground — the state the platform will grant reader mode.
+         */
+        const val NFC_HANDOFF_HOME_SETTLE_MS = 250L
 
         val DEFAULT_WATCHED_PACKAGES = setOf(
             "com.instagram.android",

--- a/app/src/main/kotlin/com/defang/launcher/service/accessibility/DefangAccessibilityService.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/accessibility/DefangAccessibilityService.kt
@@ -11,6 +11,7 @@ import android.content.IntentFilter
 import android.os.Build
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
+import com.defang.launcher.data.local.datastore.PreferencesDataStore
 import com.defang.launcher.data.repository.AppConfigRepository
 import com.defang.launcher.data.repository.WatchedUrlRepository
 import com.defang.launcher.domain.model.AppConfig
@@ -25,6 +26,8 @@ import com.defang.launcher.domain.usecase.SelectContentTrackUseCase
 import com.defang.launcher.service.overlay.CooldownOverlay
 import com.defang.launcher.service.overlay.EndCardOverlay
 import com.defang.launcher.service.overlay.IntentGateOverlay
+import com.defang.launcher.service.nfc.NfcUnlock
+import com.defang.launcher.service.nfc.NfcUnlockActivity
 import com.defang.launcher.service.overlay.OverlayManager
 import com.defang.launcher.service.overlay.SessionTimerOverlay
 import com.defang.launcher.ui.widget.UsageWidgetProvider
@@ -38,6 +41,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
@@ -73,6 +77,7 @@ class DefangAccessibilityService : AccessibilityService() {
     @Inject lateinit var browserUrlExtractor: BrowserUrlExtractor
     @Inject lateinit var watchedUrlRepo: WatchedUrlRepository
     @Inject lateinit var grayscale: GrayscaleController
+    @Inject lateinit var prefs: PreferencesDataStore
 
     private val serviceScope = CoroutineScope(Dispatchers.Main + Job())
 
@@ -133,6 +138,25 @@ class DefangAccessibilityService : AccessibilityService() {
     // swiped away, switched to home) sees no re-foreground and ends for real.
     private var pendingEndJob: Job? = null
 
+    // Set when an NFC-mode gate hands off to NfcUnlockActivity at countdown end;
+    // the NFC result broadcast invokes one of these, then both are cleared. Only
+    // one gate is ever active, so a single pair suffices.
+    private var pendingNfcUnlock: (() -> Unit)? = null
+    private var pendingNfcGoBack: (() -> Unit)? = null
+
+    private val nfcReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            val unlock = pendingNfcUnlock
+            val goBack = pendingNfcGoBack
+            pendingNfcUnlock = null
+            pendingNfcGoBack = null
+            when (intent?.action) {
+                NfcUnlock.ACTION_NFC_UNLOCKED -> unlock?.invoke()
+                NfcUnlock.ACTION_NFC_GOBACK -> goBack?.invoke()
+            }
+        }
+    }
+
     // Lock screen desaturation: gray goes on at screen-off so the lock screen
     // (and everything glanced at before unlocking) renders colorless; color
     // returns at unlock unless a session or gate is active.
@@ -171,6 +195,17 @@ class DefangAccessibilityService : AccessibilityService() {
         } else {
             @Suppress("UnspecifiedRegisterReceiverFlag")
             registerReceiver(screenReceiver, filter)
+        }
+
+        val nfcFilter = IntentFilter().apply {
+            addAction(NfcUnlock.ACTION_NFC_UNLOCKED)
+            addAction(NfcUnlock.ACTION_NFC_GOBACK)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(nfcReceiver, nfcFilter, RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            registerReceiver(nfcReceiver, nfcFilter)
         }
 
         lastUsageEventQueryMs = System.currentTimeMillis()
@@ -438,6 +473,14 @@ class DefangAccessibilityService : AccessibilityService() {
     ) {
         serviceScope.launch {
             val opensToday = getTodayOpenCount.count()
+            // NFC-tag unlock replaces the slide for app gates (not browser-URL
+            // gates — relaunching a browser can't restore the page) when the user
+            // has enabled it, registered a tag, and NFC is currently on.
+            val nfcMode = pattern == null &&
+                prefs.nfcUnlockEnabled.first() &&
+                prefs.nfcTagUid.first() != null &&
+                NfcUnlock.isUsable(this@DefangAccessibilityService)
+
             currentGateOverlay = IntentGateOverlay(
                 context = this@DefangAccessibilityService,
                 contentTrack = contentTrack,
@@ -445,32 +488,69 @@ class DefangAccessibilityService : AccessibilityService() {
                 offlinePrompt = offlinePromptSelector.next(),
                 delaySeconds = config.gateDelaySeconds,
                 opensToday = opensToday,
+                nfcMode = nfcMode,
                 onTimerFinished = {
                     // Re-assert grayscale the moment the wait ends, while the gate
                     // still fully covers the screen, so the feed is already gray
-                    // when "Open" reveals it — no color flash on the way in.
+                    // when the app reveals it — no color flash on the way in.
                     serviceScope.launch { grayscale.enable() }
-                },
-                onIntentDeclared = { intent ->
-                    pendingGate.remove(gateKey)
-                    currentGateOverlay?.cancel()
-                    overlayManager.dismissFullscreen()
-                    serviceScope.launch {
-                        startSession(pkg, pattern, intent, config.sessionLimitMinutes,
-                            config.cooldownMinutes, contentTrack)
+                    if (nfcMode) {
+                        // Hand off to the tag-scan activity: arm the result
+                        // callbacks, drop the overlay, launch the reader.
+                        pendingNfcUnlock = {
+                            completeGateUnlock(pkg, pattern, "nfc", config, contentTrack, gateKey)
+                        }
+                        pendingNfcGoBack = { completeGateGoBack(gateKey, pkg) }
+                        overlayManager.dismissFullscreen()
+                        launchNfcUnlock(config.appLabel)
                     }
                 },
-                onGoBack = {
-                    pendingGate.remove(gateKey)
-                    gateSuppressedUntilMs[gateKey] = System.currentTimeMillis() + GO_BACK_SUPPRESS_MS
-                    currentGateOverlay?.cancel()
-                    overlayManager.dismissAll()
-                    exitWatchedApp(pkg)
+                onIntentDeclared = { intent ->
+                    completeGateUnlock(pkg, pattern, intent, config, contentTrack, gateKey)
                 },
+                onGoBack = { completeGateGoBack(gateKey, pkg) },
             )
             overlayManager.showFullscreen(currentGateOverlay!!.view)
-            Log.d(TAG, "gate overlay shown for $gateKey")
+            Log.d(TAG, "gate overlay shown for $gateKey (nfc=$nfcMode)")
         }
+    }
+
+    /** Shared unlock path for both the slide gate and the NFC tag scan. */
+    private fun completeGateUnlock(
+        pkg: String,
+        pattern: String?,
+        intent: String?,
+        config: AppConfig,
+        contentTrack: ContentTrack,
+        gateKey: String,
+    ) {
+        pendingGate.remove(gateKey)
+        currentGateOverlay?.cancel()
+        overlayManager.dismissFullscreen()
+        serviceScope.launch {
+            startSession(pkg, pattern, intent, config.sessionLimitMinutes,
+                config.cooldownMinutes, contentTrack)
+        }
+    }
+
+    /** Shared "Go back" path for both the slide gate and the NFC tag scan. */
+    private fun completeGateGoBack(gateKey: String, pkg: String) {
+        pendingGate.remove(gateKey)
+        gateSuppressedUntilMs[gateKey] = System.currentTimeMillis() + GO_BACK_SUPPRESS_MS
+        currentGateOverlay?.cancel()
+        overlayManager.dismissAll()
+        exitWatchedApp(pkg)
+    }
+
+    /** Launches the tag-scan screen; its result comes back via [nfcReceiver]. */
+    private fun launchNfcUnlock(appLabel: String) {
+        startActivity(
+            Intent(this, NfcUnlockActivity::class.java).apply {
+                putExtra(NfcUnlock.EXTRA_MODE, NfcUnlock.MODE_UNLOCK)
+                putExtra(NfcUnlock.EXTRA_APP_LABEL, appLabel)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        )
     }
 
     // ── Session ───────────────────────────────────────────────────────────────
@@ -801,6 +881,7 @@ class DefangAccessibilityService : AccessibilityService() {
         foregroundPollJob?.cancel()
         foregroundPollJob = null
         runCatching { unregisterReceiver(screenReceiver) }
+        runCatching { unregisterReceiver(nfcReceiver) }
         runBlocking { endCurrentSession() }
     }
 

--- a/app/src/main/kotlin/com/defang/launcher/service/nfc/NfcUnlock.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/nfc/NfcUnlock.kt
@@ -44,4 +44,15 @@ object NfcUnlock {
 
     /** Tag UID as uppercase hex, the form stored in prefs and compared against. */
     fun uidHex(id: ByteArray): String = id.joinToString("") { "%02X".format(it) }
+
+    /**
+     * True if the UID is a *randomized* one, regenerated on every tap — the form
+     * secure cards (national eID, passports, most current contactless bank cards,
+     * and phone/watch HCE wallets like Garmin Pay) present for anti-tracking. Per
+     * ISO/IEC 14443-3, a single-size 4-byte UID beginning with 0x08 is a random
+     * number, not a fixed identity, so it can never be matched against later and
+     * is useless as a key. 7- and 10-byte UIDs are always manufacturer-fixed.
+     */
+    fun isRandomUid(id: ByteArray): Boolean =
+        id.size == 4 && id[0] == 0x08.toByte()
 }

--- a/app/src/main/kotlin/com/defang/launcher/service/nfc/NfcUnlock.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/nfc/NfcUnlock.kt
@@ -1,0 +1,47 @@
+package com.defang.launcher.service.nfc
+
+import android.content.Context
+import android.nfc.NfcAdapter
+
+/**
+ * Shared constants for the NFC-tag unlock flow, plus a couple of small helpers.
+ *
+ * The unlock is a physical-friction gate: instead of the slide-to-open at the
+ * end of the intent gate, the user must tap a specific NFC tag (registered once
+ * in settings) to open a watched app. Reading a tag requires a resumed Activity
+ * — the gate itself is a View overlay inside the AccessibilityService and can't
+ * read NFC — so [NfcUnlockActivity] does the reading and reports the result back
+ * to the service by broadcast.
+ */
+object NfcUnlock {
+    /** Intent extra: which mode [NfcUnlockActivity] runs in. */
+    const val EXTRA_MODE = "com.defang.launcher.nfc.MODE"
+
+    /** Register a new tag (from settings): capture its UID and store it. */
+    const val MODE_REGISTER = "register"
+
+    /** Verify the registered tag to open a watched app (from the gate). */
+    const val MODE_UNLOCK = "unlock"
+
+    /** Intent extra: the watched app's label, shown on the unlock screen. */
+    const val EXTRA_APP_LABEL = "com.defang.launcher.nfc.APP_LABEL"
+
+    /** Broadcast (to our own package): the registered tag was scanned — open. */
+    const val ACTION_NFC_UNLOCKED = "com.defang.launcher.nfc.UNLOCKED"
+
+    /** Broadcast: the user backed out of the unlock screen — treat as "Go back". */
+    const val ACTION_NFC_GOBACK = "com.defang.launcher.nfc.GOBACK"
+
+    /** True if this device has NFC hardware and it is currently switched on. */
+    fun isUsable(context: Context): Boolean {
+        val adapter = NfcAdapter.getDefaultAdapter(context) ?: return false
+        return adapter.isEnabled
+    }
+
+    /** Whether the device has NFC hardware at all (regardless of on/off). */
+    fun hasHardware(context: Context): Boolean =
+        NfcAdapter.getDefaultAdapter(context) != null
+
+    /** Tag UID as uppercase hex, the form stored in prefs and compared against. */
+    fun uidHex(id: ByteArray): String = id.joinToString("") { "%02X".format(it) }
+}

--- a/app/src/main/kotlin/com/defang/launcher/service/nfc/NfcUnlockActivity.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/nfc/NfcUnlockActivity.kt
@@ -1,0 +1,220 @@
+package com.defang.launcher.service.nfc
+
+import android.content.Intent
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import com.defang.launcher.R
+import com.defang.launcher.data.local.datastore.PreferencesDataStore
+import com.defang.launcher.ui.theme.DefangTheme
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * The activity that actually reads an NFC tag — reader mode requires a resumed
+ * Activity, which the gate's overlay (living in the AccessibilityService) is not.
+ *
+ * Two modes ([NfcUnlock.MODE_REGISTER] / [NfcUnlock.MODE_UNLOCK]):
+ *  - REGISTER (from settings): capture the tapped tag's UID, store it, finish.
+ *  - UNLOCK (from the gate): compare the tapped tag to the stored UID; on a match
+ *    broadcast [NfcUnlock.ACTION_NFC_UNLOCKED] so the service opens the app.
+ *    Backing out broadcasts [NfcUnlock.ACTION_NFC_GOBACK] — the same "Go back"
+ *    the slide gate offers, i.e. the app is left unopened. There is deliberately
+ *    no slide fallback here: NFC is available (the service only launches this
+ *    when it is), so the only ways out are the right tag or backing out.
+ */
+@AndroidEntryPoint
+class NfcUnlockActivity : ComponentActivity(), NfcAdapter.ReaderCallback {
+
+    @Inject lateinit var prefs: PreferencesDataStore
+
+    private var adapter: NfcAdapter? = null
+
+    private val mode: String by lazy {
+        intent.getStringExtra(NfcUnlock.EXTRA_MODE) ?: NfcUnlock.MODE_UNLOCK
+    }
+    private val appLabel: String by lazy {
+        intent.getStringExtra(NfcUnlock.EXTRA_APP_LABEL).orEmpty()
+    }
+
+    private sealed interface Status {
+        data object Waiting : Status
+        data object WrongTag : Status
+        data object NfcOff : Status
+    }
+
+    private var status by mutableStateOf<Status>(Status.Waiting)
+    // Guards against double-handling a tag while the coroutine that finishes the
+    // activity is still in flight.
+    private var handled = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        adapter = NfcAdapter.getDefaultAdapter(this)
+        setContent {
+            DefangTheme {
+                BackHandler { goBack() }
+                UnlockScreen(
+                    isRegister = mode == NfcUnlock.MODE_REGISTER,
+                    appLabel = appLabel,
+                    nfcOff = status is Status.NfcOff,
+                    wrongTag = status is Status.WrongTag,
+                    onBack = { goBack() },
+                    onOpenNfcSettings = {
+                        startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
+                    },
+                )
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val a = adapter
+        if (a == null || !a.isEnabled) {
+            status = Status.NfcOff
+            return
+        }
+        status = Status.Waiting
+        a.enableReaderMode(
+            this,
+            this,
+            NfcAdapter.FLAG_READER_NFC_A or NfcAdapter.FLAG_READER_NFC_B or
+                NfcAdapter.FLAG_READER_NFC_F or NfcAdapter.FLAG_READER_NFC_V or
+                NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK,
+            null,
+        )
+    }
+
+    override fun onPause() {
+        super.onPause()
+        adapter?.disableReaderMode(this)
+    }
+
+    /** Reader-mode callback — runs on a binder thread, so hop to the main scope. */
+    override fun onTagDiscovered(tag: Tag) {
+        val uid = NfcUnlock.uidHex(tag.id)
+        lifecycleScope.launch {
+            if (handled) return@launch
+            when (mode) {
+                NfcUnlock.MODE_REGISTER -> {
+                    handled = true
+                    prefs.setNfcTagUid(uid)
+                    setResult(RESULT_OK)
+                    finish()
+                }
+                else -> {
+                    val stored = prefs.nfcTagUid.first()
+                    if (stored != null && stored.equals(uid, ignoreCase = true)) {
+                        handled = true
+                        sendBroadcast(
+                            Intent(NfcUnlock.ACTION_NFC_UNLOCKED).setPackage(packageName)
+                        )
+                        finish()
+                    } else {
+                        // Wrong tag — keep reading so the user can try the right one.
+                        status = Status.WrongTag
+                    }
+                }
+            }
+        }
+    }
+
+    private fun goBack() {
+        if (handled) return
+        handled = true
+        if (mode == NfcUnlock.MODE_UNLOCK) {
+            sendBroadcast(Intent(NfcUnlock.ACTION_NFC_GOBACK).setPackage(packageName))
+        }
+        finish()
+    }
+}
+
+@Composable
+private fun UnlockScreen(
+    isRegister: Boolean,
+    appLabel: String,
+    nfcOff: Boolean,
+    wrongTag: Boolean,
+    onBack: () -> Unit,
+    onOpenNfcSettings: () -> Unit,
+) {
+    Scaffold(containerColor = MaterialTheme.colorScheme.background) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            val wrong = wrongTag
+
+            val title = when {
+                nfcOff -> stringResource(R.string.nfc_off_title)
+                isRegister -> stringResource(R.string.nfc_register_title)
+                else -> stringResource(R.string.nfc_unlock_title, appLabel)
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = when {
+                    nfcOff -> stringResource(R.string.nfc_off_body)
+                    wrong -> stringResource(R.string.nfc_wrong_tag)
+                    isRegister -> stringResource(R.string.nfc_register_body)
+                    else -> stringResource(R.string.nfc_unlock_body)
+                },
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (wrong)
+                    MaterialTheme.colorScheme.error
+                else
+                    MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+
+            if (nfcOff) {
+                TextButton(onClick = onOpenNfcSettings, modifier = Modifier.padding(top = 24.dp)) {
+                    Text(stringResource(R.string.nfc_open_settings))
+                }
+            }
+
+            TextButton(onClick = onBack, modifier = Modifier.padding(top = 16.dp)) {
+                Text(
+                    text = if (isRegister)
+                        stringResource(R.string.action_cancel)
+                    else
+                        stringResource(R.string.gate_go_back),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/defang/launcher/service/nfc/NfcUnlockActivity.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/nfc/NfcUnlockActivity.kt
@@ -4,28 +4,44 @@ import android.content.Intent
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.os.Bundle
-import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
+import kotlin.math.roundToInt
 import com.defang.launcher.R
 import com.defang.launcher.data.local.datastore.PreferencesDataStore
 import com.defang.launcher.ui.theme.DefangTheme
@@ -64,6 +80,7 @@ class NfcUnlockActivity : ComponentActivity(), NfcAdapter.ReaderCallback {
     private sealed interface Status {
         data object Waiting : Status
         data object WrongTag : Status
+        data object RandomTag : Status
         data object NfcOff : Status
     }
 
@@ -71,10 +88,29 @@ class NfcUnlockActivity : ComponentActivity(), NfcAdapter.ReaderCallback {
     // Guards against double-handling a tag while the coroutine that finishes the
     // activity is still in flight.
     private var handled = false
+    // Revealed after a grace period with no successful scan: a slide-to-open
+    // backup so an app whose NFC the platform won't hand us (Snapchat hijacks the
+    // reader on some devices) can still be opened rather than being locked out.
+    private var showSlide by mutableStateOf(false)
+    // Tracks a genuine focus loss, so we only re-arm the reader when focus truly
+    // returns — arming twice in quick succession while a card is already in the
+    // field makes the platform drop reader mode ("active polling is forced to
+    // disable now" → "Binder was never registered").
+    private var lostFocus = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         adapter = NfcAdapter.getDefaultAdapter(this)
+
+        // Unlock only: after a grace period without a successful scan, reveal the
+        // slide-to-open backup. Registration has no such fallback.
+        if (mode == NfcUnlock.MODE_UNLOCK) {
+            lifecycleScope.launch {
+                kotlinx.coroutines.delay(NFC_FALLBACK_MS)
+                if (!handled) showSlide = true
+            }
+        }
+
         setContent {
             DefangTheme {
                 BackHandler { goBack() }
@@ -83,10 +119,10 @@ class NfcUnlockActivity : ComponentActivity(), NfcAdapter.ReaderCallback {
                     appLabel = appLabel,
                     nfcOff = status is Status.NfcOff,
                     wrongTag = status is Status.WrongTag,
+                    randomTag = status is Status.RandomTag,
+                    showSlide = showSlide,
+                    onSlideComplete = { unlockViaFallback() },
                     onBack = { goBack() },
-                    onOpenNfcSettings = {
-                        startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
-                    },
                 )
             }
         }
@@ -94,12 +130,33 @@ class NfcUnlockActivity : ComponentActivity(), NfcAdapter.ReaderCallback {
 
     override fun onResume() {
         super.onResume()
+        armReader()
+    }
+
+    /**
+     * Re-arm on regained window focus too. Reader mode is bound to the resumed,
+     * focused activity; some apps (Snapchat) briefly steal focus without a full
+     * pause/resume, and the platform revokes our reader mode when that happens.
+     * Re-enabling here recovers as soon as focus comes back.
+     */
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (!hasFocus) {
+            lostFocus = true
+        } else if (lostFocus) {
+            lostFocus = false
+            armReader()   // only re-arm after a real focus loss, never redundantly
+        }
+    }
+
+    private fun armReader() {
+        if (handled) return
         val a = adapter
         if (a == null || !a.isEnabled) {
             status = Status.NfcOff
             return
         }
-        status = Status.Waiting
+        status = if (status is Status.NfcOff) Status.Waiting else status
         a.enableReaderMode(
             this,
             this,
@@ -115,9 +172,32 @@ class NfcUnlockActivity : ComponentActivity(), NfcAdapter.ReaderCallback {
         adapter?.disableReaderMode(this)
     }
 
+    /**
+     * The activity is noHistory, so being stopped means it's finishing — the user
+     * left (Home, app switch, screen off) without scanning. Treat that as "Go
+     * back" so the gate resolves instead of wedging as permanently pending. The
+     * success and explicit-back paths set [handled] first, so they skip this.
+     */
+    override fun onStop() {
+        super.onStop()
+        if (!handled) {
+            handled = true
+            if (mode == NfcUnlock.MODE_UNLOCK) {
+                sendBroadcast(Intent(NfcUnlock.ACTION_NFC_GOBACK).setPackage(packageName))
+            }
+        }
+    }
+
     /** Reader-mode callback — runs on a binder thread, so hop to the main scope. */
     override fun onTagDiscovered(tag: Tag) {
         val uid = NfcUnlock.uidHex(tag.id)
+        // Reject randomized-UID cards up front: they present a different UID every
+        // tap, so registering one guarantees a "wrong tag" on the very next scan.
+        // Keep reading so the user can try a proper tag without leaving.
+        if (mode == NfcUnlock.MODE_REGISTER && NfcUnlock.isRandomUid(tag.id)) {
+            runOnUiThread { status = Status.RandomTag }
+            return
+        }
         lifecycleScope.launch {
             if (handled) return@launch
             when (mode) {
@@ -152,6 +232,19 @@ class NfcUnlockActivity : ComponentActivity(), NfcAdapter.ReaderCallback {
         }
         finish()
     }
+
+    /** Slide backup completed — unlock exactly as a successful tag scan would. */
+    private fun unlockViaFallback() {
+        if (handled) return
+        handled = true
+        sendBroadcast(Intent(NfcUnlock.ACTION_NFC_UNLOCKED).setPackage(packageName))
+        finish()
+    }
+
+    private companion object {
+        /** Grace period before the slide-to-open backup appears. */
+        const val NFC_FALLBACK_MS = 10_000L
+    }
 }
 
 @Composable
@@ -160,8 +253,10 @@ private fun UnlockScreen(
     appLabel: String,
     nfcOff: Boolean,
     wrongTag: Boolean,
+    randomTag: Boolean,
+    showSlide: Boolean,
+    onSlideComplete: () -> Unit,
     onBack: () -> Unit,
-    onOpenNfcSettings: () -> Unit,
 ) {
     Scaffold(containerColor = MaterialTheme.colorScheme.background) { padding ->
         Column(
@@ -172,10 +267,11 @@ private fun UnlockScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            val wrong = wrongTag
+            val isError = wrongTag || randomTag
 
             val title = when {
                 nfcOff -> stringResource(R.string.nfc_off_title)
+                randomTag -> stringResource(R.string.nfc_random_title)
                 isRegister -> stringResource(R.string.nfc_register_title)
                 else -> stringResource(R.string.nfc_unlock_title, appLabel)
             }
@@ -188,12 +284,13 @@ private fun UnlockScreen(
             Text(
                 text = when {
                     nfcOff -> stringResource(R.string.nfc_off_body)
-                    wrong -> stringResource(R.string.nfc_wrong_tag)
+                    randomTag -> stringResource(R.string.nfc_random_body)
+                    wrongTag -> stringResource(R.string.nfc_wrong_tag)
                     isRegister -> stringResource(R.string.nfc_register_body)
                     else -> stringResource(R.string.nfc_unlock_body)
                 },
                 style = MaterialTheme.typography.bodyLarge,
-                color = if (wrong)
+                color = if (isError)
                     MaterialTheme.colorScheme.error
                 else
                     MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
@@ -201,10 +298,15 @@ private fun UnlockScreen(
                 modifier = Modifier.padding(top = 16.dp),
             )
 
-            if (nfcOff) {
-                TextButton(onClick = onOpenNfcSettings, modifier = Modifier.padding(top = 24.dp)) {
-                    Text(stringResource(R.string.nfc_open_settings))
-                }
+            if (showSlide && !isRegister) {
+                Text(
+                    text = stringResource(R.string.nfc_slide_fallback),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(top = 40.dp, bottom = 8.dp),
+                )
+                SlideToOpen(onComplete = onSlideComplete)
             }
 
             TextButton(onClick = onBack, modifier = Modifier.padding(top = 16.dp)) {
@@ -216,5 +318,57 @@ private fun UnlockScreen(
                 )
             }
         }
+    }
+}
+
+/** Minimal slide-to-open: drag the thumb to the far end to confirm. */
+@Composable
+private fun SlideToOpen(onComplete: () -> Unit) {
+    val trackHeight = 64.dp
+    val thumb = 56.dp
+    var trackWidthPx by remember { mutableFloatStateOf(0f) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    var done by remember { mutableStateOf(false) }
+    val density = LocalDensity.current
+    val thumbPx = with(density) { thumb.toPx() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(trackHeight)
+            .clip(RoundedCornerShape(trackHeight / 2))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .onSizeChanged { trackWidthPx = it.width.toFloat() },
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+            text = stringResource(R.string.nfc_slide_label),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+        )
+        Box(
+            modifier = Modifier
+                .offset { IntOffset(offsetX.roundToInt(), 0) }
+                .padding(4.dp)
+                .size(thumb - 8.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary)
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = { if (!done) offsetX = 0f },
+                        onHorizontalDrag = { change, drag ->
+                            change.consume()
+                            val max = (trackWidthPx - thumbPx).coerceAtLeast(0f)
+                            offsetX = (offsetX + drag).coerceIn(0f, max)
+                            if (!done && offsetX >= max - 2f) {
+                                done = true
+                                onComplete()
+                            }
+                        },
+                    )
+                },
+        )
     }
 }

--- a/app/src/main/kotlin/com/defang/launcher/service/overlay/IntentGateOverlay.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/overlay/IntentGateOverlay.kt
@@ -51,6 +51,11 @@ class IntentGateOverlay(
     private val offlinePrompt: String?,
     private val delaySeconds: Int,
     private val opensToday: Int,
+    // When true, the unlock is a physical NFC-tag scan handled by the service:
+    // this overlay shows only the tidbit + countdown, and the service dismisses
+    // it and hands off to NfcUnlockActivity once the countdown ends. No slide is
+    // revealed. When false, the slide-to-open below is the unlock, as before.
+    private val nfcMode: Boolean = false,
     private val onTimerFinished: () -> Unit,
     private val onIntentDeclared: (intent: String?) -> Unit,
     private val onGoBack: () -> Unit,
@@ -193,8 +198,12 @@ class IntentGateOverlay(
     private fun onTimerElapsed() {
         tvCountdown.text = ""
         timerDone = true
-        tvSlideHint.visibility = View.VISIBLE
-        slideToOpen.visibility = View.VISIBLE
+        // In NFC mode the service takes over here — dismisses this overlay and
+        // launches the tag-scan activity — so we never reveal the slide.
+        if (!nfcMode) {
+            tvSlideHint.visibility = View.VISIBLE
+            slideToOpen.visibility = View.VISIBLE
+        }
         onTimerFinished()
     }
 

--- a/app/src/main/kotlin/com/defang/launcher/ui/settings/GlobalSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/settings/GlobalSettingsViewModel.kt
@@ -102,6 +102,27 @@ class GlobalSettingsViewModel @Inject constructor(
         viewModelScope.launch { prefs.removeCustomTask(task) }
     }
 
+    // ── NFC tag unlock ────────────────────────────────────────────────────────
+    val nfcUnlockEnabled: StateFlow<Boolean> = prefs.nfcUnlockEnabled.stateIn(
+        viewModelScope, SharingStarted.Eagerly, false
+    )
+    /** The registered tag UID, or null if none registered yet. */
+    val nfcTagUid: StateFlow<String?> = prefs.nfcTagUid.stateIn(
+        viewModelScope, SharingStarted.Eagerly, null
+    )
+
+    fun setNfcUnlockEnabled(on: Boolean) {
+        viewModelScope.launch { prefs.setNfcUnlockEnabled(on) }
+    }
+
+    fun forgetNfcTag() {
+        viewModelScope.launch {
+            prefs.clearNfcTagUid()
+            // No tag means nothing to require — turn the gate back to slide.
+            prefs.setNfcUnlockEnabled(false)
+        }
+    }
+
     fun setGateDelay(seconds: Int) {
         viewModelScope.launch {
             prefs.setGateDelay(seconds)

--- a/app/src/main/kotlin/com/defang/launcher/ui/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/settings/SettingsActivity.kt
@@ -52,6 +52,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.defang.launcher.R
 import com.defang.launcher.domain.model.HomeScreenMode
+import com.defang.launcher.service.nfc.NfcUnlock
+import com.defang.launcher.service.nfc.NfcUnlockActivity
 import com.defang.launcher.ui.onboarding.OnboardingActivity
 import com.defang.launcher.ui.settings.apptier.AppTierScreen
 import com.defang.launcher.ui.theme.DefangTheme
@@ -97,11 +99,25 @@ class SettingsActivity : ComponentActivity() {
                         val batchWindow1 by globalVm.batchWindow1.collectAsStateWithLifecycle()
                         val batchWindow2 by globalVm.batchWindow2.collectAsStateWithLifecycle()
                         val homeUsageOn by globalVm.homeUsageEnabled.collectAsStateWithLifecycle()
+                        val nfcEnabled by globalVm.nfcUnlockEnabled.collectAsStateWithLifecycle()
+                        val nfcTagUid by globalVm.nfcTagUid.collectAsStateWithLifecycle()
+                        val hasNfc = remember { NfcUnlock.hasHardware(this) }
                         SettingsMenuScreen(
                             homeMode = homeMode,
                             onHomeModeChange = globalVm::setHomeScreenMode,
                             homeUsageOn = homeUsageOn,
                             onHomeUsageChange = globalVm::setHomeUsageEnabled,
+                            hasNfc = hasNfc,
+                            nfcEnabled = nfcEnabled,
+                            onNfcEnabledChange = globalVm::setNfcUnlockEnabled,
+                            nfcTagUid = nfcTagUid,
+                            onRegisterNfcTag = {
+                                startActivity(
+                                    Intent(this, NfcUnlockActivity::class.java)
+                                        .putExtra(NfcUnlock.EXTRA_MODE, NfcUnlock.MODE_REGISTER)
+                                )
+                            },
+                            onForgetNfcTag = globalVm::forgetNfcTag,
                             grayscaleOn = grayscaleOn,
                             onGrayscaleChange = globalVm::setGrayscaleEnabled,
                             grayscaleSetupNeeded = grayscaleSetupNeeded,
@@ -212,6 +228,12 @@ private fun SettingsMenuScreen(
     onHomeModeChange: (HomeScreenMode) -> Unit,
     homeUsageOn: Boolean,
     onHomeUsageChange: (Boolean) -> Unit,
+    hasNfc: Boolean,
+    nfcEnabled: Boolean,
+    onNfcEnabledChange: (Boolean) -> Unit,
+    nfcTagUid: String?,
+    onRegisterNfcTag: () -> Unit,
+    onForgetNfcTag: () -> Unit,
     grayscaleOn: Boolean,
     onGrayscaleChange: (Boolean) -> Unit,
     grayscaleSetupNeeded: Boolean,
@@ -299,6 +321,8 @@ private fun SettingsMenuScreen(
         stringResource(R.string.settings_grayscale_why_body)
     val sanitizeWhy = stringResource(R.string.settings_sanitize_why_title) to
         stringResource(R.string.settings_sanitize_why_body)
+    val nfcWhy = stringResource(R.string.settings_nfc_why_title) to
+        stringResource(R.string.settings_nfc_why_body)
     val packageName = androidx.compose.ui.platform.LocalContext.current.packageName
     val grayscaleSetup = stringResource(R.string.settings_grayscale_setup_title) to
         stringResource(R.string.settings_grayscale_setup_body, packageName)
@@ -341,6 +365,62 @@ private fun SettingsMenuScreen(
                     .clickable { onSites() },
             )
             HorizontalDivider()
+
+            // NFC tag unlock — only shown on devices that have NFC hardware.
+            if (hasNfc) {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.settings_nfc_title)) },
+                    supportingContent = { Text(stringResource(R.string.settings_nfc_desc)) },
+                    trailingContent = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            WhyButton { whyDialog = nfcWhy }
+                            Switch(
+                                checked = nfcEnabled,
+                                // Can't require a tag that hasn't been registered.
+                                enabled = nfcTagUid != null,
+                                onCheckedChange = onNfcEnabledChange,
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                ListItem(
+                    headlineContent = {
+                        Text(
+                            if (nfcTagUid != null)
+                                stringResource(R.string.settings_nfc_change)
+                            else
+                                stringResource(R.string.settings_nfc_register)
+                        )
+                    },
+                    supportingContent = {
+                        Text(
+                            if (nfcTagUid != null)
+                                stringResource(
+                                    R.string.settings_nfc_registered,
+                                    nfcTagUid.takeLast(4),
+                                )
+                            else
+                                stringResource(R.string.settings_nfc_none)
+                        )
+                    },
+                    trailingContent = if (nfcTagUid != null) {
+                        {
+                            IconButton(onClick = onForgetNfcTag) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Delete,
+                                    contentDescription = stringResource(R.string.settings_nfc_forget),
+                                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                                )
+                            }
+                        }
+                    } else null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onRegisterNfcTag() },
+                )
+                HorizontalDivider()
+            }
             ListItem(
                 headlineContent = { Text(stringResource(R.string.settings_home_mode)) },
                 supportingContent = { Text(homeModeStrings(homeMode).first) },

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -178,6 +178,27 @@
     <string name="tasks_empty">Ingen oppgaver ennå. Legg til noe lite og fullførbart. Noe som tar 20 sekunder er nok.</string>
     <string name="action_back">Tilbake</string>
     <string name="action_ok">OK</string>
+    <string name="action_cancel">Avbryt</string>
+
+    <!-- NFC-brikkelås -->
+    <string name="settings_nfc_title">NFC-brikkelås</string>
+    <string name="settings_nfc_desc">Krev skanning av en fysisk brikke for å åpne overvåkede apper, i stedet for å dra. Legg brikken et sted du ikke rekker.</string>
+    <string name="settings_nfc_enable">Krev NFC-brikke</string>
+    <string name="settings_nfc_register">Registrer brikke</string>
+    <string name="settings_nfc_change">Bytt brikke</string>
+    <string name="settings_nfc_forget">Glem brikke</string>
+    <string name="settings_nfc_registered">Brikke registrert (…%1$s)</string>
+    <string name="settings_nfc_none">Ingen brikke registrert ennå</string>
+    <string name="settings_nfc_why_title">Hvorfor en fysisk brikke?</string>
+    <string name="settings_nfc_why_body">Dra-for-å-åpne er en pause, men tommelen din klarer det halvsovende. En brikke du må gå til — festet på kjøleskapet, ved inngangsdøren, i et annet rom — gjør det å åpne en overvåket app til en bevisst fysisk handling. Orker du ikke reise deg, var det svaret.</string>
+    <string name="nfc_register_title">Skann brikken for å registrere</string>
+    <string name="nfc_register_body">Hold brikken du vil bruke mot baksiden av telefonen.</string>
+    <string name="nfc_unlock_title">Skann for å åpne %1$s</string>
+    <string name="nfc_unlock_body">Hold brikken mot baksiden av telefonen.</string>
+    <string name="nfc_wrong_tag">Det er ikke den registrerte brikken. Prøv riktig brikke, eller gå tilbake.</string>
+    <string name="nfc_off_title">NFC er av</string>
+    <string name="nfc_off_body">Slå på NFC for å skanne brikken, eller gå tilbake.</string>
+    <string name="nfc_open_settings">Åpne NFC-innstillinger</string>
 
     <!-- App tier search -->
     <string name="tier_search_hint">Søk etter app eller pakkenavn</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -196,6 +196,10 @@
     <string name="nfc_unlock_title">Skann for å åpne %1$s</string>
     <string name="nfc_unlock_body">Hold brikken mot baksiden av telefonen.</string>
     <string name="nfc_wrong_tag">Det er ikke den registrerte brikken. Prøv riktig brikke, eller gå tilbake.</string>
+    <string name="nfc_random_title">Det kortet fungerer ikke</string>
+    <string name="nfc_random_body">Dette kortet bruker en tilfeldig ID — en ny for hver skanning, så den kan aldri gjenkjennes. ID-kort, pass og de fleste bankkort og telefon-/klokkelommebøker gjør dette. Bruk en egen NFC-brikke (et NTAG-klistremerke) eller et eldre kort med fast ID.</string>
+    <string name="nfc_slide_fallback">Leser ikke brikken? Noen apper blokkerer skanneren. Dra for å åpne i stedet.</string>
+    <string name="nfc_slide_label">Dra for å åpne</string>
     <string name="nfc_off_title">NFC er av</string>
     <string name="nfc_off_body">Slå på NFC for å skanne brikken, eller gå tilbake.</string>
     <string name="nfc_open_settings">Åpne NFC-innstillinger</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,27 @@
     <string name="tasks_empty">No tasks yet. Add something small and completable — 20 seconds is enough.</string>
     <string name="action_back">Back</string>
     <string name="action_ok">OK</string>
+    <string name="action_cancel">Cancel</string>
+
+    <!-- NFC tag unlock -->
+    <string name="settings_nfc_title">NFC tag unlock</string>
+    <string name="settings_nfc_desc">Require a physical tag scan to open watched apps, in place of the slide. Put the tag somewhere out of reach.</string>
+    <string name="settings_nfc_enable">Require NFC tag</string>
+    <string name="settings_nfc_register">Register tag</string>
+    <string name="settings_nfc_change">Change tag</string>
+    <string name="settings_nfc_forget">Forget tag</string>
+    <string name="settings_nfc_registered">Tag registered (…%1$s)</string>
+    <string name="settings_nfc_none">No tag registered yet</string>
+    <string name="settings_nfc_why_title">Why a physical tag?</string>
+    <string name="settings_nfc_why_body">The slide-to-open is a pause, but your thumb can do it half-asleep. A tag you have to walk to — stuck to the fridge, by the front door, in another room — turns opening a watched app into a deliberate physical act. If you can\'t be bothered to get up, that was the answer.</string>
+    <string name="nfc_register_title">Scan the tag to register</string>
+    <string name="nfc_register_body">Hold the tag you want to use against the back of your phone.</string>
+    <string name="nfc_unlock_title">Scan to open %1$s</string>
+    <string name="nfc_unlock_body">Hold your tag against the back of your phone.</string>
+    <string name="nfc_wrong_tag">That\'s not the registered tag. Try the right one, or go back.</string>
+    <string name="nfc_off_title">NFC is off</string>
+    <string name="nfc_off_body">Turn on NFC to scan your tag, or go back.</string>
+    <string name="nfc_open_settings">Open NFC settings</string>
 
     <!-- App tier search -->
     <string name="tier_search_hint">Search by app or package name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,10 @@
     <string name="nfc_unlock_title">Scan to open %1$s</string>
     <string name="nfc_unlock_body">Hold your tag against the back of your phone.</string>
     <string name="nfc_wrong_tag">That\'s not the registered tag. Try the right one, or go back.</string>
+    <string name="nfc_random_title">That card won\'t work</string>
+    <string name="nfc_random_body">This card uses a randomized ID — a new one every tap, so it can never be matched. National ID cards, passports, and most bank cards and phone/watch wallets do this. Use a dedicated NFC tag (an NTAG sticker) or an older card with a fixed ID.</string>
+    <string name="nfc_slide_fallback">Tag not reading? Some apps block the scanner. Slide to open instead.</string>
+    <string name="nfc_slide_label">Slide to open</string>
     <string name="nfc_off_title">NFC is off</string>
     <string name="nfc_off_body">Turn on NFC to scan your tag, or go back.</string>
     <string name="nfc_open_settings">Open NFC settings</string>


### PR DESCRIPTION
## What

Adds an optional **NFC-tag unlock** to the intent gate. Instead of the slide-to-open at the end of the countdown, the user taps a physical NFC tag (registered once in settings) to open a watched app. Put the tag somewhere inconvenient — the fridge, the front door — and opening Instagram costs a walk. Stronger deliberateness friction than a thumb slide.

## How it works

- Reader mode needs a resumed Activity, which the gate's overlay (inside the AccessibilityService) is not — so `NfcUnlockActivity` reads the tag and reports back to the service by broadcast (`UNLOCKED` / `GOBACK`). `NfcUnlock` holds the shared constants/helpers.
- The gate overlay gains an `nfcMode` flag: it shows only tidbit + countdown and skips the slide; at countdown end the service backgrounds the app, dismisses the overlay, and launches the scan screen. `completeGateUnlock` / `completeGateGoBack` are shared by the slide and NFC paths.
- On unlock the watched app is relaunched (finishing the scan otherwise lands on home).

## Scope (v1)

- One global tag, all watched **app** gates. Browser-URL gates keep the slide (relaunching a browser can't restore the page).
- Fallback to the slide when NFC is off/absent or no tag is registered — never a hard lockout. "Go back" always exits.
- Settings → **NFC tag unlock** section (shown only on NFC hardware): enable, register/change, forget.

## Device-tested (Galaxy S22)

- **Random-UID cards rejected at registration.** National IDs, passports, most contactless bank cards, and phone/watch wallets emit a fresh UID each tap (ISO 14443 `0x08` prefix) — they'd register once then never match. Clear message instead. (A Norwegian BankAxept VISA with a fixed UID works.)
- **Timed slide fallback.** Some apps (Snapchat) hijack the NFC reader — the platform revokes our reader mode ~0.3s after we arm it and restores the app's claim, so the tag never reads. After ~10s with no scan, a slide-to-open backup appears so the app is never locked out, while NFC stays primary everywhere it works (FB/IG read instantly).
- **Stale-gate self-heal.** An abandoned gate (e.g. the scan backgrounded) used to wedge an app so its gate never re-fired; now tracked via `activeGateKey` + `onStop`→Go-back so the gate always resolves.

## Notes

- New permission: `android.permission.NFC` (`uses-feature` not required).
- Manifest gains `NfcUnlockActivity` (`excludeFromRecents`, `noHistory`).
- Strings added EN + NB.
- Snapchat's reader hijack is not fixable from the app; the slide fallback is the intended handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)