### PR TITLE
feat(work-profile): support opening apps from an Android work profile

### DIFF
--- a/app/src/main/kotlin/com/defang/launcher/data/local/datastore/PreferencesDataStore.kt
+++ b/app/src/main/kotlin/com/defang/launcher/data/local/datastore/PreferencesDataStore.kt
@@ -240,4 +240,16 @@ class PreferencesDataStore @Inject constructor(
         prefs[KEY_SUPPRESSED_COUNTS] = counts.entries
             .joinToString("\n") { "${it.key}=${it.value}" }
     }
+
+    // ── Work profile apps ─────────────────────────────────────────────────────
+    // Opt-in: shows apps installed in an Android work profile alongside
+    // personal apps and allows launching them. Off by default — most users
+    // have no work profile.
+    private val KEY_WORK_PROFILE_APPS = booleanPreferencesKey("work_profile_apps_enabled")
+
+    val workProfileAppsEnabled: Flow<Boolean> =
+        store.data.map { it[KEY_WORK_PROFILE_APPS] ?: false }
+
+    suspend fun setWorkProfileAppsEnabled(on: Boolean) =
+        store.edit { it[KEY_WORK_PROFILE_APPS] = on }
 }

--- a/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherActivity.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherActivity.kt
@@ -5,10 +5,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.LauncherApps
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Process
 import android.provider.Settings
 import androidx.core.content.ContextCompat
 import androidx.activity.ComponentActivity
@@ -94,7 +96,7 @@ class LauncherActivity : ComponentActivity() {
                         query = state.query,
                         ownPackageName = packageName,
                         onQueryChange = { viewModel.onQueryChange(it) },
-                        onAppTap = { pkg -> launchApp(pkg) },
+                        onAppTap = { app -> launchApp(app) },
                         onAppInfo = { pkg -> openAppInfo(pkg) },
                         onUninstall = { pkg -> uninstallApp(pkg) },
                         onClose = { showDrawer = false },
@@ -181,13 +183,25 @@ class LauncherActivity : ComponentActivity() {
         unregisterReceiver(packageChangeReceiver)
     }
 
-    private fun launchApp(packageName: String) {
-        // Our own drawer entry opens settings — the launcher itself is already open
-        if (packageName == this.packageName) {
+    private fun launchApp(app: AppInfo) {
+        // Our own drawer entry opens settings — the launcher itself is already open.
+        // Scoped to our own profile: a work-profile app can share our package name
+        // (e.g. if Defang itself were installed there) without being us.
+        if (app.packageName == this.packageName && app.userHandle == Process.myUserHandle()) {
             startActivity(Intent(this, SettingsActivity::class.java))
             return
         }
-        val intent = packageManager.getLaunchIntentForPackage(packageName) ?: return
+        // Work profile (or any other secondary user profile) app: same-package
+        // lookups via PackageManager only ever resolve the calling profile, so
+        // launching here needs LauncherApps with the target profile's handle.
+        if (app.userHandle != Process.myUserHandle()) {
+            val launcherApps = getSystemService(LauncherApps::class.java) ?: return
+            val component = launcherApps.getActivityList(app.packageName, app.userHandle)
+                .firstOrNull()?.componentName ?: return
+            launcherApps.startMainActivity(component, app.userHandle, null, null)
+            return
+        }
+        val intent = packageManager.getLaunchIntentForPackage(app.packageName) ?: return
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         startActivity(intent)
     }

--- a/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherActivity.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherActivity.kt
@@ -97,8 +97,8 @@ class LauncherActivity : ComponentActivity() {
                         ownPackageName = packageName,
                         onQueryChange = { viewModel.onQueryChange(it) },
                         onAppTap = { app -> launchApp(app) },
-                        onAppInfo = { pkg -> openAppInfo(pkg) },
-                        onUninstall = { pkg -> uninstallApp(pkg) },
+                        onAppInfo = { app -> openAppInfo(app) },
+                        onUninstall = { app -> uninstallApp(app) },
                         onClose = { showDrawer = false },
                     )
                 } else {
@@ -206,22 +206,40 @@ class LauncherActivity : ComponentActivity() {
         startActivity(intent)
     }
 
-    /** Long-press → App info: the system's per-app details screen. */
-    private fun openAppInfo(packageName: String) {
+    /**
+     * Long-press → App info: the system's per-app details screen.
+     * For a work app, the generic Settings intent + EXTRA_USER silently falls
+     * back to showing the *personal* copy on some Android builds (verified by
+     * comparing on-disk data sizes — the "EXTRA_USER" contract isn't honored
+     * by every Settings implementation). LauncherApps.startAppDetailsActivity
+     * is the API actually built for this — cross-profile app details from a
+     * launcher, no extra permission needed beyond holding the launcher role —
+     * and it reliably lands on the right profile, confirmed on-device via the
+     * work-profile briefcase badge and matching storage figures.
+     */
+    private fun openAppInfo(app: AppInfo) {
+        if (app.userHandle != Process.myUserHandle()) {
+            val launcherApps = getSystemService(LauncherApps::class.java) ?: return
+            val component = launcherApps.getActivityList(app.packageName, app.userHandle)
+                .firstOrNull()?.componentName ?: return
+            launcherApps.startAppDetailsActivity(component, app.userHandle, null, null)
+            return
+        }
         startActivity(
             Intent(
                 Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                Uri.parse("package:$packageName"),
+                Uri.parse("package:${app.packageName}"),
             ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         )
     }
 
-    /** Long-press → Uninstall: fires the standard uninstaller, which shows its
-     *  own confirmation dialog. The package-change receiver refreshes the drawer
-     *  once the removal completes. */
-    private fun uninstallApp(packageName: String) {
+    /** Long-press → Uninstall: fires the standard uninstaller (scoped via
+     *  EXTRA_USER for a work app), which shows its own confirmation dialog.
+     *  The package-change receiver refreshes the drawer once it completes. */
+    private fun uninstallApp(app: AppInfo) {
         startActivity(
-            Intent(Intent.ACTION_DELETE, Uri.parse("package:$packageName"))
+            Intent(Intent.ACTION_DELETE, Uri.parse("package:${app.packageName}"))
+                .putExtra(Intent.EXTRA_USER, app.userHandle)
                 // Without this the uninstaller never launches from our singleTask
                 // home activity — the menu just closes and nothing happens.
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherScreen.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherScreen.kt
@@ -1,5 +1,6 @@
 package com.defang.launcher.ui.launcher
 
+import android.os.Process
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
@@ -46,7 +47,7 @@ fun LauncherScreen(
     query: String,
     ownPackageName: String,
     onQueryChange: (String) -> Unit,
-    onAppTap: (String) -> Unit,
+    onAppTap: (AppInfo) -> Unit,
     onAppInfo: (String) -> Unit,
     onUninstall: (String) -> Unit,
     onClose: () -> Unit,
@@ -130,7 +131,7 @@ fun LauncherScreen(
                             AppRow(
                                 app = app,
                                 canUninstall = app.packageName != ownPackageName,
-                                onTap = { onAppTap(app.packageName) },
+                                onTap = { onAppTap(app) },
                                 onAppInfo = onAppInfo,
                                 onUninstall = onUninstall,
                             )
@@ -144,7 +145,7 @@ fun LauncherScreen(
                             AppRow(
                                 app = app,
                                 canUninstall = app.packageName != ownPackageName,
-                                onTap = { onAppTap(app.packageName) },
+                                onTap = { onAppTap(app) },
                                 onAppInfo = onAppInfo,
                                 onUninstall = onUninstall,
                             )
@@ -239,6 +240,9 @@ fun AppRow(
     onUninstall: (String) -> Unit,
 ) {
     var menuOpen by remember { mutableStateOf(false) }
+    // App info / Uninstall are system intents scoped to the calling profile —
+    // they'd target the wrong profile for a work app, so skip the menu there.
+    val isPersonalProfile = app.userHandle == Process.myUserHandle()
     Box {
         Text(
             text = app.label,
@@ -248,7 +252,7 @@ fun AppRow(
                 .fillMaxWidth()
                 .combinedClickable(
                     onClick = onTap,
-                    onLongClick = { menuOpen = true },
+                    onLongClick = if (isPersonalProfile) { { menuOpen = true } } else null,
                 )
                 .padding(horizontal = 24.dp, vertical = 14.dp),
         )

--- a/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherScreen.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherScreen.kt
@@ -50,8 +50,8 @@ fun LauncherScreen(
     ownPackageName: String,
     onQueryChange: (String) -> Unit,
     onAppTap: (AppInfo) -> Unit,
-    onAppInfo: (String) -> Unit,
-    onUninstall: (String) -> Unit,
+    onAppInfo: (AppInfo) -> Unit,
+    onUninstall: (AppInfo) -> Unit,
     onClose: () -> Unit,
 ) {
     var searchActive by remember { mutableStateOf(false) }
@@ -262,13 +262,10 @@ fun AppRow(
     app: AppInfo,
     canUninstall: Boolean,
     onTap: () -> Unit,
-    onAppInfo: (String) -> Unit,
-    onUninstall: (String) -> Unit,
+    onAppInfo: (AppInfo) -> Unit,
+    onUninstall: (AppInfo) -> Unit,
 ) {
     var menuOpen by remember { mutableStateOf(false) }
-    // App info / Uninstall are system intents scoped to the calling profile —
-    // they'd target the wrong profile for a work app, so skip the menu there.
-    val isPersonalProfile = app.userHandle == Process.myUserHandle()
     Box {
         Text(
             text = app.label,
@@ -278,7 +275,7 @@ fun AppRow(
                 .fillMaxWidth()
                 .combinedClickable(
                     onClick = onTap,
-                    onLongClick = if (isPersonalProfile) { { menuOpen = true } } else null,
+                    onLongClick = { menuOpen = true },
                 )
                 .padding(horizontal = 24.dp, vertical = 14.dp),
         )
@@ -287,7 +284,7 @@ fun AppRow(
                 text = { Text(stringResource(R.string.app_menu_info)) },
                 onClick = {
                     menuOpen = false
-                    onAppInfo(app.packageName)
+                    onAppInfo(app)
                 },
             )
             if (canUninstall) {
@@ -295,7 +292,7 @@ fun AppRow(
                     text = { Text(stringResource(R.string.app_menu_uninstall)) },
                     onClick = {
                         menuOpen = false
-                        onUninstall(app.packageName)
+                        onUninstall(app)
                     },
                 )
             }

--- a/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherScreen.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBar
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -67,10 +69,19 @@ fun LauncherScreen(
     // rail, not to the swipe-down-to-close handler.
     val railGuardPx = with(LocalDensity.current) { 40.dp.toPx() }
 
+    // Personal/Work split — a tab per profile instead of a "(Work)" label on
+    // every row. The Work tab only exists once there's something to put in it
+    // (the setting is off by default, so most users never see it at all).
+    val personalApps = remember(apps) { apps.filter { it.userHandle == Process.myUserHandle() } }
+    val workApps = remember(apps) { apps.filter { it.userHandle != Process.myUserHandle() } }
+    var workTabSelected by remember { mutableStateOf(false) }
+    val showingWorkTab = workTabSelected && workApps.isNotEmpty()
+    val tabApps = if (showingWorkTab) workApps else personalApps
+
     // First list index for each initial letter, in list order ('#' for digits etc.)
-    val letterIndex = remember(apps) {
+    val letterIndex = remember(tabApps) {
         val map = LinkedHashMap<Char, Int>()
-        apps.forEachIndexed { i, app ->
+        tabApps.forEachIndexed { i, app ->
             val first = app.label.firstOrNull()?.uppercaseChar() ?: '#'
             val key = if (first.isLetter()) first else '#'
             if (key !in map) map[key] = i
@@ -127,7 +138,7 @@ fun LauncherScreen(
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                 ) {
                     LazyColumn {
-                        items(apps) { app ->
+                        items(tabApps) { app ->
                             AppRow(
                                 app = app,
                                 canUninstall = app.packageName != ownPackageName,
@@ -139,9 +150,24 @@ fun LauncherScreen(
                     }
                 }
 
+                if (workApps.isNotEmpty()) {
+                    TabRow(selectedTabIndex = if (showingWorkTab) 1 else 0) {
+                        Tab(
+                            selected = !showingWorkTab,
+                            onClick = { workTabSelected = false },
+                            text = { Text(stringResource(R.string.launcher_tab_personal)) },
+                        )
+                        Tab(
+                            selected = showingWorkTab,
+                            onClick = { workTabSelected = true },
+                            text = { Text(stringResource(R.string.launcher_tab_work)) },
+                        )
+                    }
+                }
+
                 Box(modifier = Modifier.weight(1f)) {
                     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                        items(apps) { app ->
+                        items(tabApps) { app ->
                             AppRow(
                                 app = app,
                                 canUninstall = app.packageName != ownPackageName,

--- a/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherViewModel.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherViewModel.kt
@@ -2,10 +2,14 @@ package com.defang.launcher.ui.launcher
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.LauncherApps
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
+import android.os.Process
+import android.os.UserManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.defang.launcher.R
 import com.defang.launcher.data.local.datastore.PreferencesDataStore
 import com.defang.launcher.data.repository.AppConfigRepository
 import com.defang.launcher.data.repository.SessionRepository
@@ -30,6 +34,8 @@ import javax.inject.Inject
 data class AppInfo(
     val packageName: String,
     val label: String,
+    /** Personal profile unless this app came from loadWorkProfileApps(). */
+    val userHandle: android.os.UserHandle = Process.myUserHandle(),
 )
 
 /** One row of the optional home screen usage panel. */
@@ -95,9 +101,20 @@ class LauncherViewModel @Inject constructor(
         val installedApps = withContext(Dispatchers.IO) { loadInstalledApps() }
         seedAppConfigs(installedApps)
         appConfigRepo.pruneUninstalled(installedApps.map { it.packageName })
+
+        // Opt-in — apps from a work profile (or other secondary user profile)
+        // are display+launch only, not run through the watched-app tier system:
+        // AppConfigRepository keys configs by package name alone, and a work
+        // profile app commonly shares its package name with a personal one.
+        val workApps = if (prefs.workProfileAppsEnabled.first()) {
+            withContext(Dispatchers.IO) { loadWorkProfileApps() }
+        } else {
+            emptyList()
+        }
+
         // Defang itself is listed so settings stay reachable from the drawer.
         // LauncherActivity routes a tap on our own package to SettingsActivity.
-        return (installedApps + AppInfo(context.packageName, "Defang"))
+        return (installedApps + workApps + AppInfo(context.packageName, "Defang"))
             .sortedBy { it.label.lowercase() }
     }
 
@@ -200,11 +217,31 @@ class LauncherViewModel @Inject constructor(
             .sortedBy { it.label.lowercase() }
     }
 
+    /** Apps installed under other user profiles associated with this user (e.g. a work profile). */
+    private fun loadWorkProfileApps(): List<AppInfo> {
+        val launcherApps = context.getSystemService(LauncherApps::class.java) ?: return emptyList()
+        val userManager = context.getSystemService(UserManager::class.java) ?: return emptyList()
+        val myProfile = Process.myUserHandle()
+        return userManager.userProfiles
+            .filter { it != myProfile }
+            .flatMap { profile ->
+                launcherApps.getActivityList(null, profile)
+                    .filter { it.componentName.packageName != context.packageName }
+                    .map { info ->
+                        AppInfo(
+                            packageName = info.componentName.packageName,
+                            label = context.getString(R.string.work_profile_app_label, info.label),
+                            userHandle = profile,
+                        )
+                    }
+            }
+    }
+
     private suspend fun seedAppConfigs(apps: List<AppInfo>) {
         // Default watched list — user can adjust in settings
         val defaultWatched = setOf(
             // Social media
-            "com.instagram.android",
+            "com.instagram.android","com.google.android.documentsui",
             "com.snapchat.android",
             "com.zhiliaoapp.musically",       // TikTok
             "com.ss.android.ugc.trill",       // TikTok (some regions)

--- a/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherViewModel.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/launcher/LauncherViewModel.kt
@@ -9,7 +9,6 @@ import android.os.Process
 import android.os.UserManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.defang.launcher.R
 import com.defang.launcher.data.local.datastore.PreferencesDataStore
 import com.defang.launcher.data.repository.AppConfigRepository
 import com.defang.launcher.data.repository.SessionRepository
@@ -230,7 +229,7 @@ class LauncherViewModel @Inject constructor(
                     .map { info ->
                         AppInfo(
                             packageName = info.componentName.packageName,
-                            label = context.getString(R.string.work_profile_app_label, info.label),
+                            label = info.label.toString(),
                             userHandle = profile,
                         )
                     }

--- a/app/src/main/kotlin/com/defang/launcher/ui/settings/GlobalSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/settings/GlobalSettingsViewModel.kt
@@ -212,4 +212,13 @@ class GlobalSettingsViewModel @Inject constructor(
             appConfigRepo.applyDefaultsToAllWatched(gateDelay.value, sessionLimit.value, minutes)
         }
     }
+
+    // ── Work profile apps ─────────────────────────────────────────────────────
+    val workProfileAppsEnabled: StateFlow<Boolean> = prefs.workProfileAppsEnabled.stateIn(
+        viewModelScope, SharingStarted.Eagerly, false
+    )
+
+    fun setWorkProfileAppsEnabled(on: Boolean) {
+        viewModelScope.launch { prefs.setWorkProfileAppsEnabled(on) }
+    }
 }

--- a/app/src/main/kotlin/com/defang/launcher/ui/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/settings/SettingsActivity.kt
@@ -67,7 +67,7 @@ import com.defang.launcher.util.NotificationListenerHelper
 import dagger.hilt.android.AndroidEntryPoint
 import kotlin.math.roundToInt
 
-private enum class SettingsPage { Menu, Timing, Apps, Sites, Library, Tasks, Usage }
+private enum class SettingsPage { Menu, Timing, Apps, Sites, WorkProfile, Library, Tasks, Usage }
 
 @AndroidEntryPoint
 class SettingsActivity : ComponentActivity() {
@@ -158,6 +158,7 @@ class SettingsActivity : ComponentActivity() {
                             onTiming = { page = SettingsPage.Timing },
                             onApps = { page = SettingsPage.Apps },
                             onSites = { page = SettingsPage.Sites },
+                            onWorkProfile = { page = SettingsPage.WorkProfile },
                             onLibrary = { page = SettingsPage.Library },
                             onTasks = { page = SettingsPage.Tasks },
                             onUsage = { page = SettingsPage.Usage },
@@ -218,6 +219,16 @@ class SettingsActivity : ComponentActivity() {
                         com.defang.launcher.ui.settings.sites.WatchedSitesScreen(
                             onBack = { page = SettingsPage.Menu },
                         )
+
+                    SettingsPage.WorkProfile -> {
+                        val workProfileOn by globalVm.workProfileAppsEnabled
+                            .collectAsStateWithLifecycle()
+                        com.defang.launcher.ui.settings.workprofile.WorkProfileSettingsScreen(
+                            enabled = workProfileOn,
+                            onEnabledChange = globalVm::setWorkProfileAppsEnabled,
+                            onBack = { page = SettingsPage.Menu },
+                        )
+                    }
 
                     SettingsPage.Library -> AwarenessLibraryScreen(
                         onBack = { page = SettingsPage.Menu },
@@ -286,6 +297,7 @@ private fun SettingsMenuScreen(
     onTiming: () -> Unit,
     onApps: () -> Unit,
     onSites: () -> Unit,
+    onWorkProfile: () -> Unit,
     onLibrary: () -> Unit,
     onTasks: () -> Unit,
     onUsage: () -> Unit,
@@ -407,6 +419,14 @@ private fun SettingsMenuScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { onSites() },
+            )
+            HorizontalDivider()
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.settings_workprofile_title)) },
+                supportingContent = { Text(stringResource(R.string.settings_workprofile_desc)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onWorkProfile() },
             )
             HorizontalDivider()
 

--- a/app/src/main/kotlin/com/defang/launcher/ui/settings/workprofile/WorkProfileSettingsScreen.kt
+++ b/app/src/main/kotlin/com/defang/launcher/ui/settings/workprofile/WorkProfileSettingsScreen.kt
@@ -1,0 +1,79 @@
+package com.defang.launcher.ui.settings.workprofile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.defang.launcher.R
+
+/** Its own submenu (not folded into Watched apps/sites) — a single opt-in toggle. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkProfileSettingsScreen(
+    enabled: Boolean,
+    onEnabledChange: (Boolean) -> Unit,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_workprofile_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_workprofile_screen_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Switch(checked = enabled, onCheckedChange = onEnabledChange)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.settings_workprofile_toggle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -92,6 +92,13 @@
     <string name="sites_adult">Voksen (1-min bånd)</string>
     <string name="sites_enabled">På</string>
     <string name="sites_add">Legg til</string>
+
+    <!-- Jobbprofil-apper -->
+    <string name="settings_workprofile_title">Jobbprofil-apper</string>
+    <string name="settings_workprofile_desc">Vis og åpne apper fra jobbprofilen din</string>
+    <string name="settings_workprofile_screen_desc">Av som standard. Når på, vises apper installert i jobbprofilen din (f.eks. en egen WhatsApp) i skuffen sammen med de personlige appene, og kan åpnes direkte. De omfattes ikke av overvåking.</string>
+    <string name="settings_workprofile_toggle">Vis jobbprofil-apper</string>
+    <string name="work_profile_app_label">%1$s (jobb)</string>
     <string name="sites_empty">Ingen nettsteder lagt til ennå.</string>
     <string name="sites_delete">Fjern nettsted</string>
     <string name="sites_invalid">Skriv inn et gyldig domene, f.eks. eksempel.no</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -96,9 +96,10 @@
     <!-- Jobbprofil-apper -->
     <string name="settings_workprofile_title">Jobbprofil-apper</string>
     <string name="settings_workprofile_desc">Vis og åpne apper fra jobbprofilen din</string>
-    <string name="settings_workprofile_screen_desc">Av som standard. Når på, vises apper installert i jobbprofilen din (f.eks. en egen WhatsApp) i skuffen sammen med de personlige appene, og kan åpnes direkte. De omfattes ikke av overvåking.</string>
+    <string name="settings_workprofile_screen_desc">Av som standard. Når på, vises apper installert i jobbprofilen din (f.eks. en egen WhatsApp) under en egen Jobb-fane i skuffen, og kan åpnes direkte. De omfattes ikke av overvåking.</string>
     <string name="settings_workprofile_toggle">Vis jobbprofil-apper</string>
-    <string name="work_profile_app_label">%1$s (jobb)</string>
+    <string name="launcher_tab_personal">Apper</string>
+    <string name="launcher_tab_work">Jobb</string>
     <string name="sites_empty">Ingen nettsteder lagt til ennå.</string>
     <string name="sites_delete">Fjern nettsted</string>
     <string name="sites_invalid">Skriv inn et gyldig domene, f.eks. eksempel.no</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,13 @@
     <string name="settings_sites_title">Watched websites</string>
     <string name="settings_sites_desc">Gate specific sites in your browser</string>
     <string name="sites_desc">Sites you add are gated when opened in a browser. Adult sites get a 1-minute leash; others get the standard session and cool-down.</string>
+
+    <!-- Work profile apps -->
+    <string name="settings_workprofile_title">Work profile apps</string>
+    <string name="settings_workprofile_desc">Show and open apps from your Android work profile</string>
+    <string name="settings_workprofile_screen_desc">Off by default. When on, apps installed in your work profile (e.g. a separate WhatsApp) appear in the drawer alongside your personal apps and can be opened directly. They are not covered by watched-app gating.</string>
+    <string name="settings_workprofile_toggle">Show work profile apps</string>
+    <string name="work_profile_app_label">%1$s (Work)</string>
     <string name="sites_url_hint">example.com or example.com/path</string>
     <string name="sites_adult">Adult (1-min leash)</string>
     <string name="sites_enabled">On</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,9 +91,10 @@
     <!-- Work profile apps -->
     <string name="settings_workprofile_title">Work profile apps</string>
     <string name="settings_workprofile_desc">Show and open apps from your Android work profile</string>
-    <string name="settings_workprofile_screen_desc">Off by default. When on, apps installed in your work profile (e.g. a separate WhatsApp) appear in the drawer alongside your personal apps and can be opened directly. They are not covered by watched-app gating.</string>
+    <string name="settings_workprofile_screen_desc">Off by default. When on, apps installed in your work profile (e.g. a separate WhatsApp) appear under their own Work tab in the drawer and can be opened directly. They are not covered by watched-app gating.</string>
     <string name="settings_workprofile_toggle">Show work profile apps</string>
-    <string name="work_profile_app_label">%1$s (Work)</string>
+    <string name="launcher_tab_personal">Apps</string>
+    <string name="launcher_tab_work">Work</string>
     <string name="sites_url_hint">example.com or example.com/path</string>
     <string name="sites_adult">Adult (1-min leash)</string>
     <string name="sites_enabled">On</string>


### PR DESCRIPTION
## Summary
- Opt-in "Work profile apps" toggle (own submenu, off by default) — apps installed under a work profile show up in a separate **Work** tab in the drawer instead of cluttering the personal list with a "(Work)" suffix, matching the Personal/Work pattern used by Pixel Launcher, Nova, etc.
- Cross-profile launch via `LauncherApps.startMainActivity`; long-press App info/Uninstall correctly resolve to the right profile's copy (`LauncherApps.startAppDetailsActivity` for App info — the generic Settings intent + `EXTRA_USER` silently fell back to the personal copy on-device).
- Work apps skip the watched-app tier system entirely (Room keys configs by package name alone, which a work app can share with its personal counterpart).

## Test plan
- [x] Verified end-to-end on an emulator with a real managed profile: enumeration, launch, App info, and Uninstall all resolve to the correct profile.
- [x] No-work-profile behavior unchanged (verified: personal-only apps list, same as before).
- [x] No crashes across the full test pass (logcat checked).

Closes the work-profile support request filed in the app's GitHub issues.