### PR TITLE
fix(gate): stop Instagram session reset/re-gate loop (#20)

### DIFF
--- a/app/schemas/com.defang.launcher.data.local.db.DefangDatabase/8.json
+++ b/app/schemas/com.defang.launcher.data.local.db.DefangDatabase/8.json
@@ -1,0 +1,270 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "4b0fb81fa86aa25e007358f220800dd0",
+    "entities": [
+      {
+        "tableName": "app_config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `appLabel` TEXT NOT NULL, `tier` INTEGER NOT NULL, `sessionLimitMinutes` INTEGER NOT NULL, `cooldownMinutes` INTEGER NOT NULL, `gateDelaySeconds` INTEGER NOT NULL, `cooldownEndsAt` INTEGER NOT NULL, `hidden` INTEGER NOT NULL, `customLabel` TEXT, `renamePromptDismissed` INTEGER NOT NULL, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appLabel",
+            "columnName": "appLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tier",
+            "columnName": "tier",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionLimitMinutes",
+            "columnName": "sessionLimitMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cooldownMinutes",
+            "columnName": "cooldownMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gateDelaySeconds",
+            "columnName": "gateDelaySeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cooldownEndsAt",
+            "columnName": "cooldownEndsAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customLabel",
+            "columnName": "customLabel",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "renamePromptDismissed",
+            "columnName": "renamePromptDismissed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `packageName` TEXT NOT NULL, `startTime` INTEGER NOT NULL, `endTime` INTEGER NOT NULL, `intentDeclared` TEXT, `extensionUsed` INTEGER NOT NULL, `watchedPattern` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intentDeclared",
+            "columnName": "intentDeclared",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extensionUsed",
+            "columnName": "extensionUsed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedPattern",
+            "columnName": "watchedPattern",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "watched_url",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pattern` TEXT NOT NULL, `label` TEXT NOT NULL, `isAdult` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `cooldownEndsAt` INTEGER NOT NULL, PRIMARY KEY(`pattern`))",
+        "fields": [
+          {
+            "fieldPath": "pattern",
+            "columnName": "pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAdult",
+            "columnName": "isAdult",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cooldownEndsAt",
+            "columnName": "cooldownEndsAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pattern"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "session_extension",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `packageName` TEXT NOT NULL, `extendedSessionId` INTEGER NOT NULL, `newSessionId` INTEGER NOT NULL, `reason` TEXT NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extendedSessionId",
+            "columnName": "extendedSessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newSessionId",
+            "columnName": "newSessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "adaptive_gate_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gateKey` TEXT NOT NULL, `level` INTEGER NOT NULL, `lastOpenAtMs` INTEGER NOT NULL, PRIMARY KEY(`gateKey`))",
+        "fields": [
+          {
+            "fieldPath": "gateKey",
+            "columnName": "gateKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenAtMs",
+            "columnName": "lastOpenAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "gateKey"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4b0fb81fa86aa25e007358f220800dd0')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/defang/launcher/data/local/db/DefangDatabase.kt
+++ b/app/src/main/kotlin/com/defang/launcher/data/local/db/DefangDatabase.kt
@@ -21,7 +21,7 @@ import com.defang.launcher.data.local.db.entity.WatchedUrlEntity
         SessionExtensionEntity::class,
         AdaptiveGateStateEntity::class,
     ],
-    version = 7,
+    version = 8,
     exportSchema = true,
 )
 abstract class DefangDatabase : RoomDatabase() {

--- a/app/src/main/kotlin/com/defang/launcher/data/local/db/dao/SessionDao.kt
+++ b/app/src/main/kotlin/com/defang/launcher/data/local/db/dao/SessionDao.kt
@@ -20,6 +20,14 @@ interface SessionDao {
     @Query("SELECT * FROM sessions WHERE id = :id LIMIT 1")
     suspend fun getById(id: Long): SessionEntity?
 
+    /**
+     * The most recent session that never got an endTime — a session left open
+     * by an unexpected process death (issue #20). Recovered on service
+     * reconnect instead of re-gating from scratch.
+     */
+    @Query("SELECT * FROM sessions WHERE endTime = 0 ORDER BY startTime DESC LIMIT 1")
+    suspend fun getOpenSession(): SessionEntity?
+
     @Query("SELECT * FROM sessions WHERE packageName = :pkg ORDER BY startTime DESC LIMIT :limit")
     fun observeForApp(pkg: String, limit: Int = 50): Flow<List<SessionEntity>>
 

--- a/app/src/main/kotlin/com/defang/launcher/data/local/db/entity/SessionEntity.kt
+++ b/app/src/main/kotlin/com/defang/launcher/data/local/db/entity/SessionEntity.kt
@@ -9,6 +9,9 @@ import androidx.room.PrimaryKey
  * intentDeclared: the string the user tapped (or null if they just waited out the countdown)
  * extensionUsed: true if the user used their daily extension during this session
  * endTime: epoch millis, 0 while session is still active
+ * watchedPattern: the browser watch-pattern/domain key for a watched-site
+ *   session (null for a watched-app session) — needed to recover an
+ *   in-progress session's cooldown target after an unexpected process death
  */
 @Entity(tableName = "sessions")
 data class SessionEntity(
@@ -18,4 +21,5 @@ data class SessionEntity(
     val endTime: Long = 0L,
     val intentDeclared: String? = null,
     val extensionUsed: Boolean = false,
+    val watchedPattern: String? = null,
 )

--- a/app/src/main/kotlin/com/defang/launcher/data/repository/SessionRepository.kt
+++ b/app/src/main/kotlin/com/defang/launcher/data/repository/SessionRepository.kt
@@ -25,20 +25,30 @@ class SessionRepository @Inject constructor(
     private val extensionDao: SessionExtensionDao,
     private val prefs: PreferencesDataStore,
 ) {
-    suspend fun startSession(packageName: String, intentDeclared: String?): Long {
+    suspend fun startSession(
+        packageName: String,
+        intentDeclared: String?,
+        pattern: String? = null,
+    ): Long {
         if (prefs.retentionLevel.first() == RetentionLevel.DONT_TRACK) return NO_TRACK_SESSION_ID
         val entity = SessionEntity(
             packageName = packageName,
             startTime = System.currentTimeMillis(),
             intentDeclared = intentDeclared,
+            watchedPattern = pattern,
         )
         return dao.insert(entity)
     }
 
     /** Starts the follow-on session for a gate extension and records [reason]
      *  linked back to [extendedSessionId], so it can be reviewed later. */
-    suspend fun startExtension(packageName: String, extendedSessionId: Long, reason: String): Long {
-        val newSessionId = startSession(packageName, intentDeclared = null)
+    suspend fun startExtension(
+        packageName: String,
+        extendedSessionId: Long,
+        reason: String,
+        pattern: String? = null,
+    ): Long {
+        val newSessionId = startSession(packageName, intentDeclared = null, pattern = pattern)
         if (newSessionId != NO_TRACK_SESSION_ID) {
             extensionDao.insert(
                 SessionExtensionEntity(
@@ -62,6 +72,9 @@ class SessionRepository @Inject constructor(
             )
         )
     }
+
+    /** The most recent session left open by an unexpected process death, if any. */
+    suspend fun getOpenSession(): SessionEntity? = dao.getOpenSession()
 
     suspend fun markExtensionUsed(sessionId: Long) {
         val existing = dao.getById(sessionId) ?: return

--- a/app/src/main/kotlin/com/defang/launcher/di/AppModule.kt
+++ b/app/src/main/kotlin/com/defang/launcher/di/AppModule.kt
@@ -125,13 +125,24 @@ object AppModule {
         }
     }
 
+    // v8: sessions gain watchedPattern, the browser watch-pattern/domain key
+    // (mirrors the in-memory `pattern` already threaded through startSession)
+    // so a session recovered after an unexpected process death (issue #20)
+    // knows whether its eventual cooldown belongs to a watched site or a
+    // watched app.
+    internal val MIGRATION_7_8 = object : Migration(7, 8) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE sessions ADD COLUMN watchedPattern TEXT DEFAULT NULL")
+        }
+    }
+
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): DefangDatabase =
         Room.databaseBuilder(context, DefangDatabase::class.java, "defang.db")
             .addMigrations(
                 MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6,
-                MIGRATION_6_7,
+                MIGRATION_6_7, MIGRATION_7_8,
             )
             .fallbackToDestructiveMigration()
             .build()

--- a/app/src/main/kotlin/com/defang/launcher/domain/usecase/RecordSessionUseCase.kt
+++ b/app/src/main/kotlin/com/defang/launcher/domain/usecase/RecordSessionUseCase.kt
@@ -1,5 +1,6 @@
 package com.defang.launcher.domain.usecase
 
+import com.defang.launcher.data.local.db.entity.SessionEntity
 import com.defang.launcher.data.repository.SessionRepository
 import javax.inject.Inject
 
@@ -7,15 +8,22 @@ class RecordSessionUseCase @Inject constructor(
     private val repo: SessionRepository,
 ) {
     /** Opens a new session record. Returns the new session ID. */
-    suspend fun start(packageName: String, intentDeclared: String?): Long =
-        repo.startSession(packageName, intentDeclared)
+    suspend fun start(packageName: String, intentDeclared: String?, pattern: String? = null): Long =
+        repo.startSession(packageName, intentDeclared, pattern)
 
     /** Opens the follow-on session for a gate extension, recording [reason]
      *  linked back to [extendedSessionId]. Returns the new session ID. */
-    suspend fun startExtension(packageName: String, extendedSessionId: Long, reason: String): Long =
-        repo.startExtension(packageName, extendedSessionId, reason)
+    suspend fun startExtension(
+        packageName: String,
+        extendedSessionId: Long,
+        reason: String,
+        pattern: String? = null,
+    ): Long = repo.startExtension(packageName, extendedSessionId, reason, pattern)
 
     /** Closes the session, optionally marking that the extension was used. */
     suspend fun end(sessionId: Long, extensionUsed: Boolean = false) =
         repo.endSession(sessionId, extensionUsed)
+
+    /** The most recent session left open by an unexpected process death, if any. */
+    suspend fun getOpenSession(): SessionEntity? = repo.getOpenSession()
 }

--- a/app/src/main/kotlin/com/defang/launcher/service/accessibility/DefangAccessibilityService.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/accessibility/DefangAccessibilityService.kt
@@ -148,6 +148,13 @@ class DefangAccessibilityService : AccessibilityService() {
     // if the app returns to the foreground within the grace window the pending
     // end is cancelled and the session survives. A genuine departure (task
     // swiped away, switched to home) sees no re-foreground and ends for real.
+    //
+    // Also used by handleForegroundChange's direct accessibility-event path
+    // (issue #20): a share sheet, camera/media picker, or permission dialog
+    // briefly taking the foreground delivers a real TYPE_WINDOW_STATE_CHANGED
+    // for a different package too, not just usage-stats churn, so both paths
+    // share this same debounce rather than the direct path tearing down
+    // instantly.
     private var pendingEndJob: Job? = null
 
     // Set when an NFC-mode gate hands off to NfcUnlockActivity at countdown end;
@@ -217,6 +224,7 @@ class DefangAccessibilityService : AccessibilityService() {
             // never leave the lock screen in color.
             grayscale.recoverIfStale()
             if (grayscale.isDeviceLocked()) grayscale.enable()
+            recoverOpenSession()
         }
 
         val filter = IntentFilter().apply {
@@ -435,9 +443,17 @@ class DefangAccessibilityService : AccessibilityService() {
 
     private suspend fun handleForegroundChange(pkg: String, browserUrl: String?) {
         Log.d(TAG, "fgChange pkg=$pkg watched=$currentWatchedPackage pending=$pendingGate")
-        // Navigating away from whatever we were watching — end that session
-        if (pkg != currentWatchedPackage && currentWatchedPackage != null) {
-            endCurrentSession()
+        // Navigating away from whatever we were watching — debounce the
+        // teardown rather than ending immediately. A share sheet, camera/media
+        // picker, permission dialog, etc. surfacing mid-session delivers a real
+        // TYPE_WINDOW_STATE_CHANGED for a different package too; ending right
+        // away tears the session down and re-arms the gate the instant it
+        // returns. If the watched package comes back to the foreground within
+        // the grace window, cancelPendingSessionEnd() (called below and from
+        // handleBrowserUrl) drops this and the session survives.
+        val leavingPkg = currentWatchedPackage
+        if (pkg != leavingPkg && leavingPkg != null) {
+            scheduleSessionEnd(leavingPkg)
         }
 
         // Browser: delegate to URL-based logic
@@ -813,7 +829,7 @@ class DefangAccessibilityService : AccessibilityService() {
         cooldownMinutes: Int,
         contentTrack: ContentTrack,
     ) {
-        val sessionId = recordSession.start(pkg, intentDeclared)
+        val sessionId = recordSession.start(pkg, intentDeclared, pattern)
         currentSessionId = sessionId
         currentWatchedPackage = pkg
         currentWatchedPattern = pattern
@@ -821,9 +837,29 @@ class DefangAccessibilityService : AccessibilityService() {
         extensionUsedThisSession = false
         grayscale.enable()
 
+        attachTimerOverlay(
+            pkg, pattern, sessionId,
+            remainingMs = sessionLimitMinutes * 60_000L,
+            cooldownMinutes, contentTrack,
+        )
+    }
+
+    /**
+     * Builds and shows the session HUD, wired to end the session normally when
+     * [remainingMs] elapses. Shared by [startSession] (full configured limit)
+     * and [recoverOpenSession] (whatever time was left when the service died).
+     */
+    private fun attachTimerOverlay(
+        pkg: String,
+        pattern: String?,
+        sessionId: Long,
+        remainingMs: Long,
+        cooldownMinutes: Int,
+        contentTrack: ContentTrack,
+    ) {
         currentTimerOverlay = SessionTimerOverlay(
             context = this,
-            sessionLimitMs = sessionLimitMinutes * 60_000L,
+            sessionLimitMs = remainingMs,
             onSessionExpired = {
                 serviceScope.launch {
                     onSessionExpired(pkg, pattern, sessionId, cooldownMinutes, contentTrack)
@@ -831,6 +867,65 @@ class DefangAccessibilityService : AccessibilityService() {
             },
         )
         overlayManager.showHud(currentTimerOverlay!!.view)
+    }
+
+    /**
+     * Recovers a session left open by an unexpected process death (issue #20):
+     * without this, the service comes back with no in-memory session state,
+     * the watched app is still in the foreground, and the next foreground
+     * event re-gates from scratch with the full configured limit — the app
+     * appears to "reset" mid-session, looping forever. Runs once per
+     * onServiceConnected(); a no-op when there's nothing to recover (including
+     * when retention is DONT_TRACK, since no row was ever written for such a
+     * session — recovery has nothing to read).
+     */
+    private suspend fun recoverOpenSession() {
+        val open = recordSession.getOpenSession() ?: return
+        val pkg = open.packageName
+        val pattern = open.watchedPattern
+
+        val contentTrack = if (pattern == null) {
+            selectContentTrack.forPackage(pkg)
+        } else {
+            val match = watchedUrlRepo.observeAll().first().firstOrNull { it.pattern == pattern }
+            if (match?.isAdult == true || pattern.startsWith("adult:")) ContentTrack.ADULT
+            else ContentTrack.GENERAL
+        }
+
+        val baseConfig = if (pattern == null) resolveConfig(pkg) else null
+        val config = baseConfig ?: defaultBrowserConfig(pkg)
+        val effectiveConfig = if (contentTrack == ContentTrack.ADULT) {
+            config.copy(sessionLimitMinutes = ADULT_SESSION_LIMIT_MINUTES)
+        } else config
+
+        val remaining = effectiveConfig.sessionLimitMinutes * 60_000L -
+            (System.currentTimeMillis() - open.startTime)
+
+        if (remaining <= 0L) {
+            // The limit already elapsed while the service was down — go
+            // straight to the normal expiry flow instead of resuming a HUD
+            // with negative/zero time on it.
+            currentSessionId = open.id
+            currentWatchedPackage = pkg
+            currentWatchedPattern = pattern
+            sessionStartMs = open.startTime
+            extensionUsedThisSession = open.extensionUsed
+            onSessionExpired(pkg, pattern, open.id, effectiveConfig.cooldownMinutes, contentTrack)
+            return
+        }
+
+        Log.d(TAG, "recovered open session pkg=$pkg pattern=$pattern remainingMs=$remaining")
+        currentSessionId = open.id
+        currentWatchedPackage = pkg
+        currentWatchedPattern = pattern
+        sessionStartMs = open.startTime
+        extensionUsedThisSession = open.extensionUsed
+        grayscale.enable()
+        attachTimerOverlay(
+            pkg, pattern, open.id,
+            remainingMs = remaining,
+            effectiveConfig.cooldownMinutes, contentTrack,
+        )
     }
 
     private suspend fun onSessionExpired(
@@ -891,7 +986,7 @@ class DefangAccessibilityService : AccessibilityService() {
         extensionUsedThisSession = true
         recordSession.end(sessionId, extensionUsed = true)
 
-        val newSessionId = recordSession.startExtension(pkg, sessionId, reason)
+        val newSessionId = recordSession.startExtension(pkg, sessionId, reason, pattern)
         currentSessionId = newSessionId
         sessionStartMs = System.currentTimeMillis()
 

--- a/app/src/test/kotlin/com/defang/launcher/data/local/db/DefangDatabaseMigrationTest.kt
+++ b/app/src/test/kotlin/com/defang/launcher/data/local/db/DefangDatabaseMigrationTest.kt
@@ -35,6 +35,14 @@ class DefangDatabaseMigrationTest {
         migrated.close()
     }
 
+    @Test
+    fun migrate7To8_addsSessionsWatchedPattern() {
+        helper.createDatabase(TEST_DB, 7).close()
+
+        val migrated = helper.runMigrationsAndValidate(TEST_DB, 8, true, AppModule.MIGRATION_7_8)
+        migrated.close()
+    }
+
     companion object {
         private const val TEST_DB = "migration-test"
     }

--- a/app/src/test/kotlin/com/defang/launcher/data/repository/FakeSessionDaos.kt
+++ b/app/src/test/kotlin/com/defang/launcher/data/repository/FakeSessionDaos.kt
@@ -30,6 +30,9 @@ class FakeSessionDao : SessionDao {
 
     override suspend fun getById(id: Long): SessionEntity? = rows.find { it.id == id }
 
+    override suspend fun getOpenSession(): SessionEntity? =
+        rows.filter { it.endTime == 0L }.maxByOrNull { it.startTime }
+
     override fun observeForApp(pkg: String, limit: Int): Flow<List<SessionEntity>> =
         flowOf(rows.filter { it.packageName == pkg }.sortedByDescending { it.startTime }.take(limit))
 

--- a/app/src/test/kotlin/com/defang/launcher/data/repository/SessionRepositoryTest.kt
+++ b/app/src/test/kotlin/com/defang/launcher/data/repository/SessionRepositoryTest.kt
@@ -46,6 +46,36 @@ class SessionRepositoryTest {
     }
 
     @Test
+    fun `startSession records the watched pattern for browser-domain sessions`() = runTest {
+        val repository = repo(RetentionLevel.INDEFINITE)
+
+        repository.startSession("com.android.chrome", null, pattern = "adult:example.com")
+
+        assertEquals("adult:example.com", sessionDao.rows.single().watchedPattern)
+    }
+
+    @Test
+    fun `getOpenSession returns the most recent session with no endTime`() = runTest {
+        val repository = repo(RetentionLevel.INDEFINITE)
+        val firstId = repository.startSession("com.example.app", null)
+        repository.endSession(firstId)
+        val openId = repository.startSession("com.example.app", null)
+
+        val open = repository.getOpenSession()
+
+        assertEquals(openId, open?.id)
+    }
+
+    @Test
+    fun `getOpenSession returns null when every session has ended`() = runTest {
+        val repository = repo(RetentionLevel.INDEFINITE)
+        val id = repository.startSession("com.example.app", null)
+        repository.endSession(id)
+
+        assertEquals(null, repository.getOpenSession())
+    }
+
+    @Test
     fun `startExtension links the new session back to the extended one`() = runTest {
         val repository = repo(RetentionLevel.INDEFINITE)
         val extendedId = repository.startSession("com.example.app", null)


### PR DESCRIPTION
## Summary
- Fixes #20 — during watched-app use, the session timer would sometimes reset to the full configured limit and replay the whole gate (countdown + puzzle), looping indefinitely.
- Two independent gaps, both closed:
  - `handleForegroundChange`'s direct accessibility-event path ended a session immediately with no debounce (unlike the existing Instagram-task-churn fix, which only covered the usage-stats-poll path). A share sheet, camera/media picker, or permission dialog surfacing mid-session hit this and instantly re-armed the gate. Now routed through the existing `scheduleSessionEnd`/`cancelPendingSessionEnd` debounce.
  - Session state lived only in the accessibility service's in-memory fields. If the process was killed mid-session (OEM battery management, memory pressure), `onServiceConnected()` never restored it, so the still-foreground watched app re-gated from scratch with the full limit. Sessions now persist their browser watch-pattern (schema v7→v8) and any still-open session is recovered on service reconnect, resuming the HUD with the actual remaining time (or ending normally if the limit already elapsed while the service was down).

## Test plan
- [x] `:app:testDebugUnitTest` — full suite passes, including new migration test (`migrate7To8_addsSessionsWatchedPattern`) and repository tests for `getOpenSession`/pattern persistence
- [x] `:app:assembleDebug` builds clean
- [x] On-device (Galaxy S22, debug build installed over real usage data): passed the gate for Instagram, force-stopped the app mid-session to simulate a process kill, confirmed the HUD/grayscale dropped and the DB session row stayed open, then re-enabled the accessibility service and confirmed via logcat (`recovered open session pkg=com.instagram.android ... remainingMs=...`) and on-screen HUD that the session resumed with the correct remaining time — no gate replay, no duplicate DB row — and that the recovered session still ended normally (end card + cooldown) when it ran out
- [ ] Fix 1 (debounce on the direct accessibility-event path) is covered by compile/unit checks only — not separately exercised on-device with a real transient window (share sheet/dialog), since that's hard to trigger reliably via adb

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_011Uv8YueEHTWgxr4pZfGTBg