### PR TITLE
fix(browser): recognize Fenix's F-Droid package for URL bar reading

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.defang.launcher"
         minSdk = 26
         targetSdk = 35
-        versionCode = 18
-        versionName = "0.1.17"
+        versionCode = 19
+        versionName = "0.1.18"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/kotlin/com/defang/launcher/util/BrowserUrlExtractor.kt
+++ b/app/src/main/kotlin/com/defang/launcher/util/BrowserUrlExtractor.kt
@@ -13,7 +13,8 @@ import javax.inject.Singleton
  *
  * Supported browsers and their URL bar view IDs:
  *   Chrome / Chromium-based   → url_bar
- *   Firefox                   → mozac_browser_toolbar_url_view
+ *   Firefox (Play Store)      → mozac_browser_toolbar_url_view
+ *   Firefox Fenix (F-Droid)   → mozac_browser_toolbar_url_view
  *   Samsung Internet          → location_bar_edit_text
  *   Edge, Brave, Opera        → url_bar / url_field
  *   DuckDuckGo                → omnibarTextInput
@@ -33,6 +34,14 @@ class BrowserUrlExtractor @Inject constructor() {
         ),
         "org.mozilla.firefox_beta"      to listOf(
             "org.mozilla.firefox_beta:id/mozac_browser_toolbar_url_view",
+        ),
+        // Fenix (Firefox for Android) F-Droid / GitHub build — different package ID
+        // than the Play Store build (org.mozilla.firefox) but shares the same view IDs.
+        "org.mozilla.fenix"             to listOf(
+            "org.mozilla.fenix:id/mozac_browser_toolbar_url_view",
+        ),
+        "org.mozilla.fennec_fdroid"     to listOf(
+            "org.mozilla.fennec_fdroid:id/mozac_browser_toolbar_url_view",
         ),
         "com.sec.android.app.sbrowser"  to listOf(
             "com.sec.android.app.sbrowser:id/location_bar_edit_text",

--- a/fastlane/metadata/android/en-US/changelogs/19.txt
+++ b/fastlane/metadata/android/en-US/changelogs/19.txt
@@ -1,0 +1,1 @@
+Fixes watched websites not triggering on Firefox Fenix installed from F-Droid. Its package ID differs from the Play Store build, so it fell outside the list of browsers Defang reads the address bar from.

--- a/fastlane/metadata/android/nb-NO/changelogs/19.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/19.txt
@@ -1,0 +1,1 @@
+Fikser at overvåkede nettsteder ikke ble utløst på Firefox Fenix installert fra F-Droid. Pakke-IDen er forskjellig fra Play Store-versjonen, så den falt utenfor listen over nettlesere Defang leser adressefeltet fra.


### PR DESCRIPTION
## Summary
- Fixes #22 — watched websites never triggered on Firefox Fenix installed from F-Droid.
- Fenix's F-Droid/GitHub build uses applicationId `org.mozilla.fenix` (or `org.mozilla.fennec_fdroid`), not `org.mozilla.firefox` like the Play Store build, so it fell outside `BrowserUrlExtractor`'s browser map entirely.
- Added both package IDs, reusing the existing `mozac_browser_toolbar_url_view` view ID.
- Bumped version to 0.1.18 (versionCode 19) with changelog entries.

## Test plan
- [x] `./gradlew.bat :app:compileDebugKotlin` passes
- [ ] Manual: verify watched-URL gating triggers on Fenix (F-Droid build) once released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkHJMeT8Q2B1CTfWJQGYsw