### PR TITLE
fix(notifications): respect Utility downgrade for default-watched apps

### DIFF
--- a/app/src/main/kotlin/com/defang/launcher/service/notification/DefangNotificationListenerService.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/notification/DefangNotificationListenerService.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import com.defang.launcher.data.local.datastore.PreferencesDataStore
+import com.defang.launcher.data.local.db.entity.AppConfigEntity
 import com.defang.launcher.data.repository.AppConfigRepository
 import com.defang.launcher.domain.model.AppTier
 import com.defang.launcher.service.accessibility.DefangAccessibilityService
@@ -59,16 +60,12 @@ class DefangNotificationListenerService : NotificationListenerService() {
         contactNames.refreshIfStale()
         serviceScope.launch {
             appConfigRepo.observeAll().collect { all ->
-                val watched = all.filter { it.tier == AppTier.WATCHED.dbValue }
-                val knownPackages = all.map { it.packageName }.toSet()
-                // Defaults only fill in for packages not yet seeded in the DB
-                // (cold start). Once a row exists, its tier is authoritative —
-                // otherwise a user downgrading a default-watched app (e.g.
-                // Snapchat) to Utility would never actually stop being watched.
-                val unseededDefaults = DefangAccessibilityService.DEFAULT_WATCHED_PACKAGES -
-                    knownPackages
-                watchedPackages = watched.map { it.packageName }.toSet() + unseededDefaults
-                watched.forEach { appLabels[it.packageName] = it.appLabel }
+                watchedPackages = computeWatchedPackages(
+                    all,
+                    DefangAccessibilityService.DEFAULT_WATCHED_PACKAGES,
+                )
+                all.filter { it.tier == AppTier.WATCHED.dbValue }
+                    .forEach { appLabels[it.packageName] = it.appLabel }
             }
         }
         serviceScope.launch {
@@ -146,6 +143,28 @@ class DefangNotificationListenerService : NotificationListenerService() {
         val counts = prefs.suppressedCounts.first().toMutableMap()
         if (counts.remove(pkg) != null) {
             prefs.setSuppressedCounts(counts)
+        }
+    }
+
+    companion object {
+        /**
+         * Merges DB-configured watched packages with the hardcoded default
+         * list. A default is only used as a fallback for packages with no
+         * [AppConfigEntity] row yet (cold start before seeding) — once a row
+         * exists, its tier is authoritative, so a user downgrading a
+         * default-watched app (e.g. Snapchat) to Utility actually takes
+         * effect instead of being silently overridden by the default.
+         */
+        internal fun computeWatchedPackages(
+            all: List<AppConfigEntity>,
+            defaultWatchedPackages: Set<String>,
+        ): Set<String> {
+            val watched = all.filter { it.tier == AppTier.WATCHED.dbValue }
+                .map { it.packageName }
+                .toSet()
+            val knownPackages = all.map { it.packageName }.toSet()
+            val unseededDefaults = defaultWatchedPackages - knownPackages
+            return watched + unseededDefaults
         }
     }
 }

--- a/app/src/main/kotlin/com/defang/launcher/service/notification/DefangNotificationListenerService.kt
+++ b/app/src/main/kotlin/com/defang/launcher/service/notification/DefangNotificationListenerService.kt
@@ -5,6 +5,7 @@ import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import com.defang.launcher.data.local.datastore.PreferencesDataStore
 import com.defang.launcher.data.repository.AppConfigRepository
+import com.defang.launcher.domain.model.AppTier
 import com.defang.launcher.service.accessibility.DefangAccessibilityService
 import com.defang.launcher.util.ContactNameCache
 import dagger.hilt.android.AndroidEntryPoint
@@ -57,10 +58,17 @@ class DefangNotificationListenerService : NotificationListenerService() {
         summaryPoster.ensureChannel()
         contactNames.refreshIfStale()
         serviceScope.launch {
-            appConfigRepo.observeWatched().collect { list ->
-                watchedPackages = list.map { it.packageName }.toSet() +
-                    DefangAccessibilityService.DEFAULT_WATCHED_PACKAGES
-                list.forEach { appLabels[it.packageName] = it.appLabel }
+            appConfigRepo.observeAll().collect { all ->
+                val watched = all.filter { it.tier == AppTier.WATCHED.dbValue }
+                val knownPackages = all.map { it.packageName }.toSet()
+                // Defaults only fill in for packages not yet seeded in the DB
+                // (cold start). Once a row exists, its tier is authoritative —
+                // otherwise a user downgrading a default-watched app (e.g.
+                // Snapchat) to Utility would never actually stop being watched.
+                val unseededDefaults = DefangAccessibilityService.DEFAULT_WATCHED_PACKAGES -
+                    knownPackages
+                watchedPackages = watched.map { it.packageName }.toSet() + unseededDefaults
+                watched.forEach { appLabels[it.packageName] = it.appLabel }
             }
         }
         serviceScope.launch {

--- a/app/src/test/kotlin/com/defang/launcher/service/notification/DefangNotificationListenerServiceTest.kt
+++ b/app/src/test/kotlin/com/defang/launcher/service/notification/DefangNotificationListenerServiceTest.kt
@@ -1,0 +1,51 @@
+package com.defang.launcher.service.notification
+
+import com.defang.launcher.data.local.db.entity.AppConfigEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DefangNotificationListenerServiceTest {
+
+    private val defaults = setOf("com.snapchat.android", "com.instagram.android")
+
+    @Test
+    fun `default package downgraded to Utility in DB is excluded`() {
+        val all = listOf(
+            AppConfigEntity(packageName = "com.snapchat.android", appLabel = "Snapchat", tier = 0),
+        )
+
+        val watched = DefangNotificationListenerService.computeWatchedPackages(all, defaults)
+
+        assertEquals(setOf("com.instagram.android"), watched)
+    }
+
+    @Test
+    fun `default package still watched when its DB row says so`() {
+        val all = listOf(
+            AppConfigEntity(packageName = "com.snapchat.android", appLabel = "Snapchat", tier = 1),
+        )
+
+        val watched = DefangNotificationListenerService.computeWatchedPackages(all, defaults)
+
+        assertEquals(setOf("com.snapchat.android", "com.instagram.android"), watched)
+    }
+
+    @Test
+    fun `default package with no DB row yet falls back to watched`() {
+        val watched = DefangNotificationListenerService.computeWatchedPackages(emptyList(), defaults)
+
+        assertEquals(defaults, watched)
+    }
+
+    @Test
+    fun `non-default package watched only via explicit DB tier`() {
+        val all = listOf(
+            AppConfigEntity(packageName = "com.example.chat", appLabel = "Chat", tier = 1),
+            AppConfigEntity(packageName = "com.example.calc", appLabel = "Calc", tier = 0),
+        )
+
+        val watched = DefangNotificationListenerService.computeWatchedPackages(all, defaults)
+
+        assertEquals(defaults + "com.example.chat", watched)
+    }
+}


### PR DESCRIPTION
## Summary
- `DefangNotificationListenerService` always unioned the DB-derived watched set with the hardcoded `DEFAULT_WATCHED_PACKAGES` list, so re-tiering a default-watched app (e.g. Snapchat) to Utility never stopped its notifications from being captured
- Defaults now only fill gaps for packages with no `app_config` row yet, matching `resolveConfig()`'s cold-start-fallback semantics already used in `DefangAccessibilityService`
- Extracted the merge into a pure `computeWatchedPackages()` companion function and added a headless JVM unit test covering: default downgraded to Utility, default explicitly kept Watched, default with no DB row yet (cold start), non-default app watched via explicit DB tier

Fixes #24

## Test plan
- [x] `gradlew testDebugUnitTest --tests "*DefangNotificationListenerServiceTest"` — 4/4 pass
- [x] `gradlew compileDebugKotlin` — clean
- [ ] Manual: mark Snapchat Watched → Utility in Settings, confirm notifications stop being suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)